### PR TITLE
[TESTS] Harden Student unit and integration coverage

### DIFF
--- a/tests/EnglishSeedEngine.IntegrationTests/Students/StudentsEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Students/StudentsEndpointsTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
-using FluentAssertions;
+using EnglishSeedEngine.Api.Contracts.Students;
 using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using EnglishSeedEngine.IntegrationTests.Students.TestData;
+using FluentAssertions;
 
 namespace EnglishSeedEngine.IntegrationTests.Students;
 
@@ -16,15 +18,7 @@ public sealed class StudentsEndpointsTests : ApiTestBase
     [Fact]
     public async Task CreateStudent_WithValidPayload_Returns201Created()
     {
-        var payload = new
-        {
-            fullName = "Alice Carter",
-            age = 11,
-            tutorEmail = "parent.alice@example.com",
-            targetLevel = "A2"
-        };
-
-        var response = await Client.PostAsJsonAsync("/students", payload);
+        var response = await CreateStudentAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         response.Headers.Location.Should().NotBeNull();
@@ -33,13 +27,7 @@ public sealed class StudentsEndpointsTests : ApiTestBase
     [Fact]
     public async Task CreateStudent_WhenTutorEmailAlreadyExists_Returns409Conflict()
     {
-        var payload = new
-        {
-            fullName = "Alice Carter",
-            age = 11,
-            tutorEmail = "parent.alice@example.com",
-            targetLevel = "A2"
-        };
+        var payload = new CreateStudentRequestBuilder().Build();
 
         var firstResponse = await Client.PostAsJsonAsync("/students", payload);
         var secondResponse = await Client.PostAsJsonAsync("/students", payload);
@@ -47,5 +35,61 @@ public sealed class StudentsEndpointsTests : ApiTestBase
         firstResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         secondResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
-}
 
+    [Fact]
+    public async Task GetStudentById_WithNonExistingId_Returns404NotFound()
+    {
+        var nonExistingId = Guid.NewGuid();
+        var response = await Client.GetAsync($"/students/{nonExistingId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidCreateStudentRequests))]
+    public async Task CreateStudent_WithInvalidPayload_Returns400BadRequest(CreateStudentRequest invalidRequest, string invalidField)
+    {
+        var response = await Client.PostAsJsonAsync("/students", invalidRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, $"because {invalidField} is invalid");
+    }
+
+    [Fact]
+    public async Task GetStudentById_AfterCreate_ReturnsPersistedStudent()
+    {
+        var createResponse = await CreateStudentAsync();
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        createResponse.Headers.Location.Should().NotBeNull();
+
+        var createdStudent = await createResponse.Content.ReadFromJsonAsync<StudentResponse>();
+        createdStudent.Should().NotBeNull();
+        createdStudent!.Id.Should().NotBe(Guid.Empty);
+
+        var getResponse = await Client.GetAsync($"/students/{createdStudent.Id}");
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var persistedStudent = await getResponse.Content.ReadFromJsonAsync<StudentResponse>();
+        persistedStudent.Should().NotBeNull();
+        persistedStudent!.Id.Should().Be(createdStudent.Id);
+        persistedStudent.FullName.Should().Be("Alice Carter");
+        persistedStudent.Age.Should().Be(11);
+        persistedStudent.TutorEmail.Should().Be("parent.alice@example.com");
+        persistedStudent.TargetLevel.Should().Be("A2");
+        persistedStudent.CreatedAtUtc.Should().NotBe(default);
+    }
+
+    private Task<HttpResponseMessage> CreateStudentAsync()
+    {
+        return Client.PostAsJsonAsync("/students", new CreateStudentRequestBuilder().Build());
+    }
+
+    public static TheoryData<CreateStudentRequest, string> InvalidCreateStudentRequests => new()
+    {
+        { new CreateStudentRequestBuilder().WithInvalidFullName().Build(), "fullName" },
+        { new CreateStudentRequestBuilder().WithInvalidAge().Build(), "age" },
+        { new CreateStudentRequestBuilder().WithInvalidTutorEmail().Build(), "tutorEmail" },
+        { new CreateStudentRequestBuilder().WithInvalidTargetLevel().Build(), "targetLevel" }
+    };
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/Students/TestData/CreateStudentRequestBuilder.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Students/TestData/CreateStudentRequestBuilder.cs
@@ -1,0 +1,42 @@
+using EnglishSeedEngine.Api.Contracts.Students;
+
+namespace EnglishSeedEngine.IntegrationTests.Students.TestData;
+public sealed class CreateStudentRequestBuilder
+{
+    private string _fullName = "Alice Carter";
+    private int _age = 11;
+    private string _tutorEmail = "parent.alice@example.com";
+    private string _targetLevel = "A2";
+
+    public CreateStudentRequestBuilder WithInvalidAge()
+    {
+        _age = 4;
+        return this;
+    }
+
+    public CreateStudentRequestBuilder WithInvalidFullName()
+    {
+        _fullName = string.Empty;
+        return this;
+    }
+
+    public CreateStudentRequestBuilder WithInvalidTutorEmail()
+    {
+        _tutorEmail = "not-an-email";
+        return this;
+    }
+
+    public CreateStudentRequestBuilder WithInvalidTargetLevel()
+    {
+        _targetLevel = "Z9";
+        return this;
+    }
+
+    public CreateStudentRequest Build() => new()
+    {
+        FullName = _fullName,
+        Age = _age,
+        TutorEmail = _tutorEmail,
+        TargetLevel = _targetLevel
+    };
+}

--- a/tests/EnglishSeedEngine.UnitTests/Students/StudentTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/Students/StudentTests.cs
@@ -5,17 +5,79 @@ namespace EnglishSeedEngine.UnitTests.Students;
 
 public sealed class StudentTests
 {
-    [Fact]
-    public void Create_WithInvalidAge_ThrowsArgumentOutOfRangeException()
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidFullName_ThrowsArgumentException(string invalidFullName)
+    {
+        var action = () => Student.Create(
+            invalidFullName,
+            11,
+            "parent.alice@example.com",
+            "A2",
+            DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(19)]
+    public void Create_WithInvalidAge_ThrowsArgumentOutOfRangeException(int invalidAge)
     {
         var action = () => Student.Create(
             "Alice Carter",
-            3,
+            invalidAge,
             "parent.alice@example.com",
             "A2",
             DateTime.UtcNow);
 
         action.Should().Throw<ArgumentOutOfRangeException>();
     }
-}
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidTutorEmail_ThrowsArgumentException(string invalidTutorEmail)
+    {
+        var action = () => Student.Create(
+            "Alice Carter",
+            11,
+            invalidTutorEmail,
+            "A2",
+            DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidTargetLevel_ThrowsArgumentException(string invalidTargetLevel)
+    {
+        var action = () => Student.Create(
+            "Alice Carter",
+            11,
+            "parent.alice@example.com",
+            invalidTargetLevel,
+            DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Create_WithValidData_ReturnsStudent()
+    {
+        var createdStudent = Student.Create(
+            "Alice Carter",
+            11,
+            "parent.alice@example.com",
+            "A2",
+            DateTime.UtcNow);
+
+        createdStudent.FullName.Should().Be("Alice Carter");
+        createdStudent.Age.Should().Be(11);
+        createdStudent.TutorEmail.Should().Be("parent.alice@example.com");
+        createdStudent.TargetLevel.Should().Be("A2");
+    }
+}


### PR DESCRIPTION
## Summary
- Expanded `Student` unit tests to cover validation rules for full name, age, tutor email, and target level.
- Refactored student API integration tests to use a reusable request builder and added HTTP contract cases for invalid payloads, missing students, duplicate tutor email, and persistence round-trips.
- Added a small integration test data builder to keep the suite readable as inputs grow.

## Test Coverage
- `dotnet test tests/EnglishSeedEngine.UnitTests/EnglishSeedEngine.UnitTests.csproj` ✅
- `dotnet test tests/EnglishSeedEngine.IntegrationTests/EnglishSeedEngine.IntegrationTests.csproj` ✅

## Notes
- No production code changed; this PR only improves test quality and maintainability.