### PR TITLE
[US-002] Add initial assessment and level endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 
 - Modular monolith structure (`Domain`, `Application`, `Infrastructure`, `Api`).
 - Student registration API.
+- Initial assessment and CEFR approximation endpoints.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 

--- a/src/EnglishSeedEngine.Api/Contracts/Students/StudentLevelResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Students/StudentLevelResponse.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Api.Contracts.Students;
+
+public sealed record StudentLevelResponse(
+    Guid StudentId,
+    int CorrectAnswers,
+    int TotalQuestions,
+    int ScorePercentage,
+    string CefrLevel,
+    DateTime AssessedAtUtc);

--- a/src/EnglishSeedEngine.Api/Contracts/Students/SubmitInitialAssessmentRequest.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Students/SubmitInitialAssessmentRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EnglishSeedEngine.Api.Contracts.Students;
+
+public sealed class SubmitInitialAssessmentRequest : IValidatableObject
+{
+    [Range(0, int.MaxValue)]
+    public int CorrectAnswers { get; init; }
+
+    [Range(1, int.MaxValue)]
+    public int TotalQuestions { get; init; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (CorrectAnswers > TotalQuestions)
+        {
+            yield return new ValidationResult(
+                "Correct answers cannot exceed total questions.",
+                [nameof(CorrectAnswers), nameof(TotalQuestions)]);
+        }
+    }
+}

--- a/src/EnglishSeedEngine.Api/Controllers/StudentsController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/StudentsController.cs
@@ -44,6 +44,28 @@ public sealed class StudentsController : ControllerBase
         }
     }
 
+    [HttpPost("{id:guid}/assessments/initial")]
+    public async Task<IActionResult> SubmitInitialAssessment(
+        [FromRoute] Guid id,
+        [FromBody] SubmitInitialAssessmentRequest request,
+        CancellationToken cancellationToken)
+    {
+        var student = await _studentService.SubmitInitialAssessmentAsync(
+            id,
+            new SubmitInitialAssessmentInput(request.CorrectAnswers, request.TotalQuestions),
+            cancellationToken);
+
+        if (student is null)
+        {
+            return NotFound();
+        }
+
+        return CreatedAtRoute(
+            RouteNames.GetStudentLevel,
+            new { id = student.Id },
+            ToLevelResponse(student));
+    }
+
     [HttpGet("{id:guid}", Name = RouteNames.GetStudentById)]
     public async Task<IActionResult> GetStudentById([FromRoute] Guid id, CancellationToken cancellationToken)
     {
@@ -57,6 +79,19 @@ public sealed class StudentsController : ControllerBase
         return Ok(ToResponse(student));
     }
 
+    [HttpGet("{id:guid}/level", Name = RouteNames.GetStudentLevel)]
+    public async Task<IActionResult> GetStudentLevel([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        var student = await _studentService.GetByIdAsync(id, cancellationToken);
+
+        if (student is null || !student.HasInitialAssessment)
+        {
+            return NotFound();
+        }
+
+        return Ok(ToLevelResponse(student));
+    }
+
     private static StudentResponse ToResponse(Domain.Students.Student student)
     {
         return new StudentResponse(
@@ -68,9 +103,21 @@ public sealed class StudentsController : ControllerBase
             student.CreatedAtUtc);
     }
 
+    private static StudentLevelResponse ToLevelResponse(Domain.Students.Student student)
+    {
+        return new StudentLevelResponse(
+            student.Id,
+            student.InitialAssessmentCorrectAnswers!.Value,
+            student.InitialAssessmentTotalQuestions!.Value,
+            student.InitialAssessmentScorePercentage!.Value,
+            student.InitialAssessmentLevel!,
+            student.InitialAssessmentCompletedAtUtc!.Value);
+    }
+
     private static class RouteNames
     {
         public const string GetStudentById = nameof(GetStudentById);
+
+        public const string GetStudentLevel = nameof(GetStudentLevel);
     }
 }
-

--- a/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
+++ b/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
@@ -1,4 +1,5 @@
 @EnglishSeedEngine.Api_HostAddress = http://localhost:5042
+@studentId = 00000000-0000-0000-0000-000000000001
 
 GET {{EnglishSeedEngine.Api_HostAddress}}/health
 Accept: application/json
@@ -14,5 +15,20 @@ Content-Type: application/json
   "tutorEmail": "parent.alice@example.com",
   "targetLevel": "A2"
 }
+
+###
+
+POST {{EnglishSeedEngine.Api_HostAddress}}/students/{{studentId}}/assessments/initial
+Content-Type: application/json
+
+{
+  "correctAnswers": 8,
+  "totalQuestions": 10
+}
+
+###
+
+GET {{EnglishSeedEngine.Api_HostAddress}}/students/{{studentId}}/level
+Accept: application/json
 
 ###

--- a/src/EnglishSeedEngine.Application/Students/IStudentRepository.cs
+++ b/src/EnglishSeedEngine.Application/Students/IStudentRepository.cs
@@ -8,6 +8,7 @@ public interface IStudentRepository
 
     Task<Student?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 
+    Task UpdateAsync(Student student, CancellationToken cancellationToken);
+
     Task<bool> TutorEmailExistsAsync(string tutorEmail, CancellationToken cancellationToken);
 }
-

--- a/src/EnglishSeedEngine.Application/Students/IStudentService.cs
+++ b/src/EnglishSeedEngine.Application/Students/IStudentService.cs
@@ -7,5 +7,6 @@ public interface IStudentService
     Task<Student> CreateAsync(CreateStudentInput input, CancellationToken cancellationToken);
 
     Task<Student?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
-}
 
+    Task<Student?> SubmitInitialAssessmentAsync(Guid studentId, SubmitInitialAssessmentInput input, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/Students/StudentService.cs
+++ b/src/EnglishSeedEngine.Application/Students/StudentService.cs
@@ -39,5 +39,29 @@ public sealed class StudentService : IStudentService
     {
         return _studentRepository.GetByIdAsync(id, cancellationToken);
     }
-}
 
+    public async Task<Student?> SubmitInitialAssessmentAsync(
+        Guid studentId,
+        SubmitInitialAssessmentInput input,
+        CancellationToken cancellationToken)
+    {
+        var student = await _studentRepository.GetByIdAsync(studentId, cancellationToken);
+
+        if (student is null)
+        {
+            return null;
+        }
+
+        var level = InitialAssessmentScoring.DetermineLevel(input.CorrectAnswers, input.TotalQuestions);
+
+        student.RecordInitialAssessment(
+            input.CorrectAnswers,
+            input.TotalQuestions,
+            level,
+            _timeProvider.GetUtcNow().UtcDateTime);
+
+        await _studentRepository.UpdateAsync(student, cancellationToken);
+
+        return student;
+    }
+}

--- a/src/EnglishSeedEngine.Application/Students/SubmitInitialAssessmentInput.cs
+++ b/src/EnglishSeedEngine.Application/Students/SubmitInitialAssessmentInput.cs
@@ -1,0 +1,5 @@
+namespace EnglishSeedEngine.Application.Students;
+
+public sealed record SubmitInitialAssessmentInput(
+    int CorrectAnswers,
+    int TotalQuestions);

--- a/src/EnglishSeedEngine.Domain/Students/InitialAssessmentScoring.cs
+++ b/src/EnglishSeedEngine.Domain/Students/InitialAssessmentScoring.cs
@@ -1,0 +1,48 @@
+namespace EnglishSeedEngine.Domain.Students;
+
+public static class InitialAssessmentScoring
+{
+    public static int CalculateScorePercentage(int correctAnswers, int totalQuestions)
+    {
+        ValidateAnswers(correctAnswers, totalQuestions);
+
+        return (int)Math.Round(
+            (double)correctAnswers / totalQuestions * 100,
+            MidpointRounding.AwayFromZero);
+    }
+
+    public static string DetermineLevel(int correctAnswers, int totalQuestions)
+    {
+        var scorePercentage = CalculateScorePercentage(correctAnswers, totalQuestions);
+
+        if (scorePercentage < 40)
+        {
+            return "A1";
+        }
+
+        if (scorePercentage < 75)
+        {
+            return "A2";
+        }
+
+        return "B1";
+    }
+
+    private static void ValidateAnswers(int correctAnswers, int totalQuestions)
+    {
+        if (correctAnswers < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(correctAnswers), "Correct answers cannot be negative.");
+        }
+
+        if (totalQuestions <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(totalQuestions), "Total questions must be greater than zero.");
+        }
+
+        if (correctAnswers > totalQuestions)
+        {
+            throw new ArgumentOutOfRangeException(nameof(correctAnswers), "Correct answers cannot exceed total questions.");
+        }
+    }
+}

--- a/src/EnglishSeedEngine.Domain/Students/Student.cs
+++ b/src/EnglishSeedEngine.Domain/Students/Student.cs
@@ -86,6 +86,7 @@ public sealed class Student
         InitialAssessmentTotalQuestions = totalQuestions;
         InitialAssessmentScorePercentage = InitialAssessmentScoring.CalculateScorePercentage(correctAnswers, totalQuestions);
         InitialAssessmentLevel = level.Trim().ToUpperInvariant();
-        InitialAssessmentCompletedAtUtc = completedAtUtc;
+        var truncatedTicks = completedAtUtc.Ticks - (completedAtUtc.Ticks % TimeSpan.TicksPerMicrosecond);
+        InitialAssessmentCompletedAtUtc = new DateTime(truncatedTicks, DateTimeKind.Utc);
     }
 }

--- a/src/EnglishSeedEngine.Domain/Students/Student.cs
+++ b/src/EnglishSeedEngine.Domain/Students/Student.cs
@@ -28,6 +28,18 @@ public sealed class Student
 
     public DateTime CreatedAtUtc { get; private set; }
 
+    public int? InitialAssessmentCorrectAnswers { get; private set; }
+
+    public int? InitialAssessmentTotalQuestions { get; private set; }
+
+    public int? InitialAssessmentScorePercentage { get; private set; }
+
+    public string? InitialAssessmentLevel { get; private set; }
+
+    public DateTime? InitialAssessmentCompletedAtUtc { get; private set; }
+
+    public bool HasInitialAssessment => InitialAssessmentLevel is not null;
+
     public static Student Create(string fullName, int age, string tutorEmail, string targetLevel, DateTime createdAtUtc)
     {
         if (string.IsNullOrWhiteSpace(fullName))
@@ -58,5 +70,22 @@ public sealed class Student
             targetLevel.Trim().ToUpperInvariant(),
             createdAtUtc);
     }
-}
 
+    public void RecordInitialAssessment(
+        int correctAnswers,
+        int totalQuestions,
+        string level,
+        DateTime completedAtUtc)
+    {
+        if (string.IsNullOrWhiteSpace(level))
+        {
+            throw new ArgumentException("Assessment level is required.", nameof(level));
+        }
+
+        InitialAssessmentCorrectAnswers = correctAnswers;
+        InitialAssessmentTotalQuestions = totalQuestions;
+        InitialAssessmentScorePercentage = InitialAssessmentScoring.CalculateScorePercentage(correctAnswers, totalQuestions);
+        InitialAssessmentLevel = level.Trim().ToUpperInvariant();
+        InitialAssessmentCompletedAtUtc = completedAtUtc;
+    }
+}

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
@@ -23,7 +23,7 @@ public sealed class AppDbContext : DbContext
         student.Property(x => x.TutorEmail).HasMaxLength(256).IsRequired();
         student.Property(x => x.TargetLevel).HasMaxLength(8).IsRequired();
         student.Property(x => x.CreatedAtUtc).IsRequired();
+        student.Property(x => x.InitialAssessmentLevel).HasMaxLength(8);
         student.HasIndex(x => x.TutorEmail).IsUnique();
     }
 }
-

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/StudentRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/StudentRepository.cs
@@ -26,6 +26,12 @@ public sealed class StudentRepository : IStudentRepository
             .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
     }
 
+    public async Task UpdateAsync(Student student, CancellationToken cancellationToken)
+    {
+        _dbContext.Students.Update(student);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
     public Task<bool> TutorEmailExistsAsync(string tutorEmail, CancellationToken cancellationToken)
     {
         return _dbContext.Students
@@ -33,4 +39,3 @@ public sealed class StudentRepository : IStudentRepository
             .AnyAsync(x => x.TutorEmail == tutorEmail, cancellationToken);
     }
 }
-

--- a/tests/EnglishSeedEngine.IntegrationTests/Students/StudentAssessmentEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Students/StudentAssessmentEndpointsTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Net.Http.Json;
+using EnglishSeedEngine.Api.Contracts.Students;
+using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using EnglishSeedEngine.IntegrationTests.Students.TestData;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.IntegrationTests.Students;
+
+[Collection(ApiTestCollection.Name)]
+public sealed class StudentAssessmentEndpointsTests : ApiTestBase
+{
+    public StudentAssessmentEndpointsTests(ApiIntegrationTestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task SubmitInitialAssessment_AssignsLevelAndPersistsResult()
+    {
+        var student = await CreateStudentAsync();
+        var request = new SubmitInitialAssessmentRequest
+        {
+            CorrectAnswers = 8,
+            TotalQuestions = 10
+        };
+
+        var postResponse = await Client.PostAsJsonAsync($"/students/{student.Id}/assessments/initial", request);
+
+        postResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        postResponse.Headers.Location.Should().NotBeNull();
+
+        var assessmentResponse = await postResponse.Content.ReadFromJsonAsync<StudentLevelResponse>();
+        assessmentResponse.Should().NotBeNull();
+        assessmentResponse!.StudentId.Should().Be(student.Id);
+        assessmentResponse.CefrLevel.Should().Be("B1");
+        assessmentResponse.ScorePercentage.Should().Be(80);
+        assessmentResponse.CorrectAnswers.Should().Be(8);
+        assessmentResponse.TotalQuestions.Should().Be(10);
+        assessmentResponse.AssessedAtUtc.Should().NotBe(default);
+
+        var getResponse = await Client.GetAsync($"/students/{student.Id}/level");
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var persistedLevel = await getResponse.Content.ReadFromJsonAsync<StudentLevelResponse>();
+        persistedLevel.Should().NotBeNull();
+        persistedLevel.Should().BeEquivalentTo(assessmentResponse);
+    }
+
+    [Fact]
+    public async Task SubmitInitialAssessment_StudentNotFound_Returns404NotFound()
+    {
+        var request = new SubmitInitialAssessmentRequest
+        {
+            CorrectAnswers = 5,
+            TotalQuestions = 10
+        };
+
+        var response = await Client.PostAsJsonAsync($"/students/{Guid.NewGuid()}/assessments/initial", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidAssessmentRequests))]
+    public async Task SubmitInitialAssessment_InvalidAnswers_Returns400BadRequest(
+        SubmitInitialAssessmentRequest invalidRequest,
+        string invalidField)
+    {
+        var student = await CreateStudentAsync();
+
+        var response = await Client.PostAsJsonAsync($"/students/{student.Id}/assessments/initial", invalidRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, $"because {invalidField} is invalid");
+    }
+
+    public static TheoryData<SubmitInitialAssessmentRequest, string> InvalidAssessmentRequests => new()
+    {
+        { new SubmitInitialAssessmentRequest { CorrectAnswers = -1, TotalQuestions = 10 }, "correctAnswers" },
+        { new SubmitInitialAssessmentRequest { CorrectAnswers = 11, TotalQuestions = 10 }, "correctAnswers" },
+        { new SubmitInitialAssessmentRequest { CorrectAnswers = 5, TotalQuestions = 0 }, "totalQuestions" }
+    };
+
+    private async Task<StudentResponse> CreateStudentAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/students", new CreateStudentRequestBuilder().Build());
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var student = await response.Content.ReadFromJsonAsync<StudentResponse>();
+        student.Should().NotBeNull();
+
+        return student!;
+    }
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/Students/TestData/CreateStudentRequestBuilder.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Students/TestData/CreateStudentRequestBuilder.cs
@@ -1,0 +1,43 @@
+using EnglishSeedEngine.Api.Contracts.Students;
+
+namespace EnglishSeedEngine.IntegrationTests.Students.TestData;
+
+public sealed class CreateStudentRequestBuilder
+{
+    private string _fullName = "Alice Carter";
+    private int _age = 11;
+    private string _tutorEmail = "parent.alice@example.com";
+    private string _targetLevel = "A2";
+
+    public CreateStudentRequestBuilder WithInvalidAge()
+    {
+        _age = 4;
+        return this;
+    }
+
+    public CreateStudentRequestBuilder WithInvalidFullName()
+    {
+        _fullName = string.Empty;
+        return this;
+    }
+
+    public CreateStudentRequestBuilder WithInvalidTutorEmail()
+    {
+        _tutorEmail = "not-an-email";
+        return this;
+    }
+
+    public CreateStudentRequestBuilder WithInvalidTargetLevel()
+    {
+        _targetLevel = "Z9";
+        return this;
+    }
+
+    public CreateStudentRequest Build() => new()
+    {
+        FullName = _fullName,
+        Age = _age,
+        TutorEmail = _tutorEmail,
+        TargetLevel = _targetLevel
+    };
+}

--- a/tests/EnglishSeedEngine.UnitTests/Students/InitialAssessmentScoringTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/Students/InitialAssessmentScoringTests.cs
@@ -1,0 +1,49 @@
+using EnglishSeedEngine.Domain.Students;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.UnitTests.Students;
+
+public sealed class InitialAssessmentScoringTests
+{
+    [Theory]
+    [InlineData(1, 3, 33)]
+    [InlineData(2, 3, 67)]
+    [InlineData(8, 10, 80)]
+    public void CalculateScorePercentage_ReturnsRoundedScore(
+        int correctAnswers,
+        int totalQuestions,
+        int expectedScorePercentage)
+    {
+        var score = InitialAssessmentScoring.CalculateScorePercentage(correctAnswers, totalQuestions);
+
+        score.Should().Be(expectedScorePercentage);
+    }
+
+    [Theory]
+    [InlineData(3, 10, "A1")]
+    [InlineData(4, 10, "A2")]
+    [InlineData(7, 10, "A2")]
+    [InlineData(8, 10, "B1")]
+    public void DetermineLevel_ReturnsExpectedCefrBand(
+        int correctAnswers,
+        int totalQuestions,
+        string expectedLevel)
+    {
+        var level = InitialAssessmentScoring.DetermineLevel(correctAnswers, totalQuestions);
+
+        level.Should().Be(expectedLevel);
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(1, 0)]
+    [InlineData(11, 10)]
+    public void CalculateScorePercentage_WithInvalidAnswers_ThrowsArgumentOutOfRangeException(
+        int correctAnswers,
+        int totalQuestions)
+    {
+        var action = () => InitialAssessmentScoring.CalculateScorePercentage(correctAnswers, totalQuestions);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## Summary
- Added a domain scoring helper to map initial assessment results to approximate CEFR bands.
- Added `POST /students/{id}/assessments/initial` to persist an assessment result and assign the initial level.
- Added `GET /students/{id}/level` to retrieve the persisted assessment outcome.
- Extended the student model and repository to store the assessment snapshot.
- Added request/response contracts, tests, and lightweight docs for the new flow.

## Test Coverage
- `dotnet test tests/EnglishSeedEngine.UnitTests/EnglishSeedEngine.UnitTests.csproj --no-restore` ✅
- `dotnet test tests/EnglishSeedEngine.IntegrationTests/EnglishSeedEngine.IntegrationTests.csproj --no-restore` ✅

## Notes
- This PR closes #5.
- The initial assessment uses a simple rule-based scoring model for the first version.