### PR TITLE
[US-003] Add 4-week personalized learning plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 - Modular monolith structure (`Domain`, `Application`, `Infrastructure`, `Api`).
 - Student registration API.
 - Initial assessment and CEFR approximation endpoints.
+- Personalized 4-week learning plan endpoints.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 

--- a/src/EnglishSeedEngine.Api/Contracts/LearningPlans/LearningPlanResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/LearningPlans/LearningPlanResponse.cs
@@ -1,0 +1,10 @@
+namespace EnglishSeedEngine.Api.Contracts.LearningPlans;
+
+public sealed record LearningPlanResponse(
+    Guid Id,
+    Guid StudentId,
+    string StartLevel,
+    string TargetLevel,
+    string Status,
+    DateTime CreatedAtUtc,
+    IReadOnlyCollection<LearningPlanWeeklyGoalResponse> WeeklyGoals);

--- a/src/EnglishSeedEngine.Api/Contracts/LearningPlans/LearningPlanWeeklyGoalResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/LearningPlans/LearningPlanWeeklyGoalResponse.cs
@@ -1,0 +1,5 @@
+namespace EnglishSeedEngine.Api.Contracts.LearningPlans;
+
+public sealed record LearningPlanWeeklyGoalResponse(
+    int WeekNumber,
+    string Goal);

--- a/src/EnglishSeedEngine.Api/Controllers/LearningPlansController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/LearningPlansController.cs
@@ -1,0 +1,79 @@
+using EnglishSeedEngine.Api.Contracts.LearningPlans;
+using EnglishSeedEngine.Application.LearningPlans;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EnglishSeedEngine.Api.Controllers;
+
+[ApiController]
+public sealed class LearningPlansController : ControllerBase
+{
+    private readonly ILearningPlanService _learningPlanService;
+
+    public LearningPlansController(ILearningPlanService learningPlanService)
+    {
+        _learningPlanService = learningPlanService;
+    }
+
+    [HttpPost("students/{id:guid}/learning-plans")]
+    public async Task<IActionResult> CreateLearningPlan([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var learningPlan = await _learningPlanService.CreateForStudentAsync(id, cancellationToken);
+
+            if (learningPlan is null)
+            {
+                return NotFound();
+            }
+
+            return CreatedAtRoute(
+                RouteNames.GetLearningPlanById,
+                new { id = learningPlan.Id },
+                ToResponse(learningPlan));
+        }
+        catch (MissingInitialAssessmentException ex)
+        {
+            return UnprocessableEntity(new ProblemDetails
+            {
+                Title = "Initial assessment required",
+                Detail = ex.Message,
+                Status = StatusCodes.Status422UnprocessableEntity
+            });
+        }
+    }
+
+    [HttpGet("learning-plans/{id:guid}", Name = RouteNames.GetLearningPlanById)]
+    public async Task<IActionResult> GetLearningPlanById([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        var learningPlan = await _learningPlanService.GetByIdAsync(id, cancellationToken);
+
+        if (learningPlan is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ToResponse(learningPlan));
+    }
+
+    private static LearningPlanResponse ToResponse(Domain.LearningPlans.LearningPlan learningPlan)
+    {
+        var weeklyGoals = learningPlan.WeeklyGoals
+            .OrderBy(x => x.WeekNumber)
+            .Select(x => new LearningPlanWeeklyGoalResponse(x.WeekNumber, x.Goal))
+            .ToArray();
+
+        return new LearningPlanResponse(
+            learningPlan.Id,
+            learningPlan.StudentId,
+            learningPlan.StartLevel,
+            learningPlan.TargetLevel,
+            learningPlan.Status,
+            learningPlan.CreatedAtUtc,
+            weeklyGoals);
+    }
+
+    private static class RouteNames
+    {
+        public const string GetLearningPlanById = nameof(GetLearningPlanById);
+    }
+}

--- a/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
+++ b/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
@@ -1,5 +1,6 @@
 @EnglishSeedEngine.Api_HostAddress = http://localhost:5042
 @studentId = 00000000-0000-0000-0000-000000000001
+@learningPlanId = 00000000-0000-0000-0000-000000000002
 
 GET {{EnglishSeedEngine.Api_HostAddress}}/health
 Accept: application/json
@@ -29,6 +30,15 @@ Content-Type: application/json
 ###
 
 GET {{EnglishSeedEngine.Api_HostAddress}}/students/{{studentId}}/level
+Accept: application/json
+
+###
+
+POST {{EnglishSeedEngine.Api_HostAddress}}/students/{{studentId}}/learning-plans
+
+###
+
+GET {{EnglishSeedEngine.Api_HostAddress}}/learning-plans/{{learningPlanId}}
 Accept: application/json
 
 ###

--- a/src/EnglishSeedEngine.Api/Program.cs
+++ b/src/EnglishSeedEngine.Api/Program.cs
@@ -1,3 +1,4 @@
+using EnglishSeedEngine.Application.LearningPlans;
 using EnglishSeedEngine.Application.Students;
 using EnglishSeedEngine.Infrastructure;
 using EnglishSeedEngine.Infrastructure.Persistence;
@@ -10,6 +11,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddHealthChecks();
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddScoped<ILearningPlanService, LearningPlanService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddInfrastructure(builder.Configuration);
 

--- a/src/EnglishSeedEngine.Application/LearningPlans/ILearningPlanRepository.cs
+++ b/src/EnglishSeedEngine.Application/LearningPlans/ILearningPlanRepository.cs
@@ -1,0 +1,10 @@
+using EnglishSeedEngine.Domain.LearningPlans;
+
+namespace EnglishSeedEngine.Application.LearningPlans;
+
+public interface ILearningPlanRepository
+{
+    Task AddAsync(LearningPlan learningPlan, CancellationToken cancellationToken);
+
+    Task<LearningPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/LearningPlans/ILearningPlanService.cs
+++ b/src/EnglishSeedEngine.Application/LearningPlans/ILearningPlanService.cs
@@ -1,0 +1,10 @@
+using EnglishSeedEngine.Domain.LearningPlans;
+
+namespace EnglishSeedEngine.Application.LearningPlans;
+
+public interface ILearningPlanService
+{
+    Task<LearningPlan?> CreateForStudentAsync(Guid studentId, CancellationToken cancellationToken);
+
+    Task<LearningPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/LearningPlans/LearningPlanService.cs
+++ b/src/EnglishSeedEngine.Application/LearningPlans/LearningPlanService.cs
@@ -1,0 +1,51 @@
+using EnglishSeedEngine.Application.Students;
+using EnglishSeedEngine.Domain.LearningPlans;
+
+namespace EnglishSeedEngine.Application.LearningPlans;
+
+public sealed class LearningPlanService : ILearningPlanService
+{
+    private readonly ILearningPlanRepository _learningPlanRepository;
+    private readonly IStudentRepository _studentRepository;
+    private readonly TimeProvider _timeProvider;
+
+    public LearningPlanService(
+        ILearningPlanRepository learningPlanRepository,
+        IStudentRepository studentRepository,
+        TimeProvider timeProvider)
+    {
+        _learningPlanRepository = learningPlanRepository;
+        _studentRepository = studentRepository;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<LearningPlan?> CreateForStudentAsync(Guid studentId, CancellationToken cancellationToken)
+    {
+        var student = await _studentRepository.GetByIdAsync(studentId, cancellationToken);
+
+        if (student is null)
+        {
+            return null;
+        }
+
+        if (!student.HasInitialAssessment)
+        {
+            throw new MissingInitialAssessmentException(studentId);
+        }
+
+        var learningPlan = LearningPlan.Create(
+            student.Id,
+            student.InitialAssessmentLevel!,
+            student.TargetLevel,
+            _timeProvider.GetUtcNow().UtcDateTime);
+
+        await _learningPlanRepository.AddAsync(learningPlan, cancellationToken);
+
+        return learningPlan;
+    }
+
+    public Task<LearningPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _learningPlanRepository.GetByIdAsync(id, cancellationToken);
+    }
+}

--- a/src/EnglishSeedEngine.Application/LearningPlans/MissingInitialAssessmentException.cs
+++ b/src/EnglishSeedEngine.Application/LearningPlans/MissingInitialAssessmentException.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Application.LearningPlans;
+
+public sealed class MissingInitialAssessmentException : Exception
+{
+    public MissingInitialAssessmentException(Guid studentId)
+        : base($"Student '{studentId}' must complete the initial assessment before creating a learning plan.")
+    {
+    }
+}

--- a/src/EnglishSeedEngine.Domain/LearningPlans/LearningPlan.cs
+++ b/src/EnglishSeedEngine.Domain/LearningPlans/LearningPlan.cs
@@ -1,0 +1,99 @@
+namespace EnglishSeedEngine.Domain.LearningPlans;
+
+public sealed class LearningPlan
+{
+    private LearningPlan()
+    {
+    }
+
+    private LearningPlan(
+        Guid id,
+        Guid studentId,
+        string startLevel,
+        string targetLevel,
+        DateTime createdAtUtc)
+    {
+        Id = id;
+        StudentId = studentId;
+        StartLevel = startLevel;
+        TargetLevel = targetLevel;
+        Status = "Active";
+        CreatedAtUtc = createdAtUtc;
+    }
+
+    public Guid Id { get; private set; }
+
+    public Guid StudentId { get; private set; }
+
+    public string StartLevel { get; private set; } = string.Empty;
+
+    public string TargetLevel { get; private set; } = string.Empty;
+
+    public string Status { get; private set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; private set; }
+
+    public List<LearningPlanWeeklyGoal> WeeklyGoals { get; private set; } = new();
+
+    public static LearningPlan Create(
+        Guid studentId,
+        string startLevel,
+        string targetLevel,
+        DateTime createdAtUtc)
+    {
+        if (studentId == Guid.Empty)
+        {
+            throw new ArgumentException("Student id is required.", nameof(studentId));
+        }
+
+        if (string.IsNullOrWhiteSpace(startLevel))
+        {
+            throw new ArgumentException("Start level is required.", nameof(startLevel));
+        }
+
+        if (string.IsNullOrWhiteSpace(targetLevel))
+        {
+            throw new ArgumentException("Target level is required.", nameof(targetLevel));
+        }
+
+        var normalizedStartLevel = startLevel.Trim().ToUpperInvariant();
+        var normalizedTargetLevel = targetLevel.Trim().ToUpperInvariant();
+        var normalizedCreatedAt = NormalizeUtc(createdAtUtc);
+        var planId = Guid.NewGuid();
+
+        var plan = new LearningPlan(
+            planId,
+            studentId,
+            normalizedStartLevel,
+            normalizedTargetLevel,
+            normalizedCreatedAt);
+
+        plan.WeeklyGoals = BuildWeeklyGoals(planId, normalizedStartLevel, normalizedTargetLevel);
+
+        return plan;
+    }
+
+    private static List<LearningPlanWeeklyGoal> BuildWeeklyGoals(
+        Guid learningPlanId,
+        string startLevel,
+        string targetLevel)
+    {
+        return
+        [
+            LearningPlanWeeklyGoal.Create(learningPlanId, 1, $"Consolidate {startLevel} foundations"),
+            LearningPlanWeeklyGoal.Create(learningPlanId, 2, $"Expand grammar and vocabulary towards {targetLevel}"),
+            LearningPlanWeeklyGoal.Create(learningPlanId, 3, $"Practice listening and sentence production at {targetLevel}"),
+            LearningPlanWeeklyGoal.Create(learningPlanId, 4, $"Review progress and readiness check for {targetLevel}")
+        ];
+    }
+
+    private static DateTime NormalizeUtc(DateTime value)
+    {
+        var utcValue = value.Kind == DateTimeKind.Utc
+            ? value
+            : value.ToUniversalTime();
+
+        var truncatedTicks = utcValue.Ticks - (utcValue.Ticks % TimeSpan.TicksPerMicrosecond);
+        return new DateTime(truncatedTicks, DateTimeKind.Utc);
+    }
+}

--- a/src/EnglishSeedEngine.Domain/LearningPlans/LearningPlanWeeklyGoal.cs
+++ b/src/EnglishSeedEngine.Domain/LearningPlans/LearningPlanWeeklyGoal.cs
@@ -1,0 +1,48 @@
+namespace EnglishSeedEngine.Domain.LearningPlans;
+
+public sealed class LearningPlanWeeklyGoal
+{
+    private LearningPlanWeeklyGoal()
+    {
+    }
+
+    private LearningPlanWeeklyGoal(Guid id, Guid learningPlanId, int weekNumber, string goal)
+    {
+        Id = id;
+        LearningPlanId = learningPlanId;
+        WeekNumber = weekNumber;
+        Goal = goal;
+    }
+
+    public Guid Id { get; private set; }
+
+    public Guid LearningPlanId { get; private set; }
+
+    public int WeekNumber { get; private set; }
+
+    public string Goal { get; private set; } = string.Empty;
+
+    public static LearningPlanWeeklyGoal Create(Guid learningPlanId, int weekNumber, string goal)
+    {
+        if (learningPlanId == Guid.Empty)
+        {
+            throw new ArgumentException("Learning plan id is required.", nameof(learningPlanId));
+        }
+
+        if (weekNumber is < 1 or > 4)
+        {
+            throw new ArgumentOutOfRangeException(nameof(weekNumber), "Week number must be between 1 and 4.");
+        }
+
+        if (string.IsNullOrWhiteSpace(goal))
+        {
+            throw new ArgumentException("Weekly goal is required.", nameof(goal));
+        }
+
+        return new LearningPlanWeeklyGoal(
+            Guid.NewGuid(),
+            learningPlanId,
+            weekNumber,
+            goal.Trim());
+    }
+}

--- a/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
+++ b/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using EnglishSeedEngine.Application.LearningPlans;
 using EnglishSeedEngine.Application.Students;
 using EnglishSeedEngine.Infrastructure.Persistence;
 using EnglishSeedEngine.Infrastructure.Persistence.Repositories;
@@ -20,8 +21,8 @@ public static class DependencyInjection
 
         services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
         services.AddScoped<IStudentRepository, StudentRepository>();
+        services.AddScoped<ILearningPlanRepository, LearningPlanRepository>();
 
         return services;
     }
 }
-

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
@@ -1,3 +1,4 @@
+using EnglishSeedEngine.Domain.LearningPlans;
 using EnglishSeedEngine.Domain.Students;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +13,8 @@ public sealed class AppDbContext : DbContext
 
     public DbSet<Student> Students => Set<Student>();
 
+    public DbSet<LearningPlan> LearningPlans => Set<LearningPlan>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         var student = modelBuilder.Entity<Student>();
@@ -25,5 +28,25 @@ public sealed class AppDbContext : DbContext
         student.Property(x => x.CreatedAtUtc).IsRequired();
         student.Property(x => x.InitialAssessmentLevel).HasMaxLength(8);
         student.HasIndex(x => x.TutorEmail).IsUnique();
+
+        var learningPlan = modelBuilder.Entity<LearningPlan>();
+        learningPlan.ToTable("learning_plans");
+        learningPlan.HasKey(x => x.Id);
+        learningPlan.Property(x => x.StudentId).IsRequired();
+        learningPlan.Property(x => x.StartLevel).HasMaxLength(8).IsRequired();
+        learningPlan.Property(x => x.TargetLevel).HasMaxLength(8).IsRequired();
+        learningPlan.Property(x => x.Status).HasMaxLength(24).IsRequired();
+        learningPlan.Property(x => x.CreatedAtUtc).IsRequired();
+        learningPlan.HasIndex(x => x.StudentId);
+        learningPlan.HasMany(x => x.WeeklyGoals)
+            .WithOne()
+            .HasForeignKey(x => x.LearningPlanId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        var weeklyGoal = modelBuilder.Entity<LearningPlanWeeklyGoal>();
+        weeklyGoal.ToTable("learning_plan_weekly_goals");
+        weeklyGoal.HasKey(x => x.Id);
+        weeklyGoal.Property(x => x.WeekNumber).IsRequired();
+        weeklyGoal.Property(x => x.Goal).HasMaxLength(300).IsRequired();
     }
 }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LearningPlanRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LearningPlanRepository.cs
@@ -1,0 +1,29 @@
+using EnglishSeedEngine.Application.LearningPlans;
+using EnglishSeedEngine.Domain.LearningPlans;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnglishSeedEngine.Infrastructure.Persistence.Repositories;
+
+public sealed class LearningPlanRepository : ILearningPlanRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public LearningPlanRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(LearningPlan learningPlan, CancellationToken cancellationToken)
+    {
+        await _dbContext.LearningPlans.AddAsync(learningPlan, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<LearningPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.LearningPlans
+            .AsNoTracking()
+            .Include(x => x.WeeklyGoals)
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/LearningPlans/LearningPlansEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/LearningPlans/LearningPlansEndpointsTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Net.Http.Json;
+using EnglishSeedEngine.Api.Contracts.LearningPlans;
+using EnglishSeedEngine.Api.Contracts.Students;
+using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.IntegrationTests.LearningPlans;
+
+[Collection(ApiTestCollection.Name)]
+public sealed class LearningPlansEndpointsTests : ApiTestBase
+{
+    public LearningPlansEndpointsTests(ApiIntegrationTestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreatePlan_FromAssessment_Returns201()
+    {
+        var student = await CreateStudentAsync("B1");
+        await SubmitInitialAssessmentAsync(student.Id, correctAnswers: 5, totalQuestions: 10);
+
+        var createResponse = await Client.PostAsync($"/students/{student.Id}/learning-plans", content: null);
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        createResponse.Headers.Location.Should().NotBeNull();
+
+        var createdPlan = await createResponse.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        createdPlan.Should().NotBeNull();
+        createdPlan!.StudentId.Should().Be(student.Id);
+        createdPlan.StartLevel.Should().Be("A2");
+        createdPlan.TargetLevel.Should().Be("B1");
+        createdPlan.Status.Should().Be("Active");
+        createdPlan.WeeklyGoals.Should().HaveCount(4);
+        createdPlan.WeeklyGoals.Select(x => x.WeekNumber).Should().Equal(1, 2, 3, 4);
+
+        var getResponse = await Client.GetAsync($"/learning-plans/{createdPlan.Id}");
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var persistedPlan = await getResponse.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        persistedPlan.Should().NotBeNull();
+        persistedPlan.Should().BeEquivalentTo(createdPlan);
+    }
+
+    [Fact]
+    public async Task CreatePlan_WithoutAssessment_Returns422()
+    {
+        var student = await CreateStudentAsync("B1");
+
+        var response = await Client.PostAsync($"/students/{student.Id}/learning-plans", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task GetPlan_NotFound_Returns404()
+    {
+        var response = await Client.GetAsync($"/learning-plans/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task<StudentResponse> CreateStudentAsync(string targetLevel)
+    {
+        var request = new CreateStudentRequest
+        {
+            FullName = "Plan Student",
+            Age = 12,
+            TutorEmail = $"parent.plan.{Guid.NewGuid():N}@example.com",
+            TargetLevel = targetLevel
+        };
+
+        var response = await Client.PostAsJsonAsync("/students", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var student = await response.Content.ReadFromJsonAsync<StudentResponse>();
+        student.Should().NotBeNull();
+
+        return student!;
+    }
+
+    private async Task SubmitInitialAssessmentAsync(Guid studentId, int correctAnswers, int totalQuestions)
+    {
+        var request = new SubmitInitialAssessmentRequest
+        {
+            CorrectAnswers = correctAnswers,
+            TotalQuestions = totalQuestions
+        };
+
+        var response = await Client.PostAsJsonAsync($"/students/{studentId}/assessments/initial", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}

--- a/tests/EnglishSeedEngine.UnitTests/Students/LearningPlanTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/Students/LearningPlanTests.cs
@@ -1,0 +1,48 @@
+using EnglishSeedEngine.Domain.LearningPlans;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.UnitTests.Students;
+
+public sealed class LearningPlanTests
+{
+    [Fact]
+    public void Create_GeneratesFourWeeklyGoals()
+    {
+        var plan = LearningPlan.Create(
+            Guid.NewGuid(),
+            "A2",
+            "B1",
+            DateTime.UtcNow);
+
+        plan.WeeklyGoals.Should().HaveCount(4);
+        plan.WeeklyGoals.Select(x => x.WeekNumber).Should().Equal(1, 2, 3, 4);
+    }
+
+    [Fact]
+    public void Create_UsesStartAndTargetLevelsInWeeklyGoals()
+    {
+        var plan = LearningPlan.Create(
+            Guid.NewGuid(),
+            "A2",
+            "B1",
+            DateTime.UtcNow);
+
+        plan.WeeklyGoals.Should().ContainSingle(x => x.WeekNumber == 1 && x.Goal.Contains("A2"));
+        plan.WeeklyGoals.Should().ContainSingle(x => x.WeekNumber == 2 && x.Goal.Contains("B1"));
+        plan.WeeklyGoals.Should().ContainSingle(x => x.WeekNumber == 4 && x.Goal.Contains("B1"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidStartLevel_ThrowsArgumentException(string invalidStartLevel)
+    {
+        var action = () => LearningPlan.Create(
+            Guid.NewGuid(),
+            invalidStartLevel,
+            "B1",
+            DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Summary
- Added a new `LearningPlan` domain model that generates a 4-week goal sequence based on start and target CEFR levels.
- Added API endpoints:
  - `POST /students/{id}/learning-plans`
  - `GET /learning-plans/{id}`
- Added application service/repository flow to create and fetch plans.
- Enforced business rule: creating a plan without initial assessment returns `422 UnprocessableEntity`.
- Added integration and unit tests for the new behavior.
- Updated API `.http` examples and README scope summary.

## Test Coverage
- `dotnet test --no-restore` ✅

## Notes
- Closes #6.