### PR TITLE
feat: generate next lesson from active learning plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 - Student registration API.
 - Initial assessment and CEFR approximation endpoints.
 - Personalized 4-week learning plan endpoints.
+- Next lesson generation and lesson retrieval endpoints.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 

--- a/src/EnglishSeedEngine.Api/Contracts/Lessons/LessonResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Lessons/LessonResponse.cs
@@ -1,0 +1,10 @@
+namespace EnglishSeedEngine.Api.Contracts.Lessons;
+
+public sealed record LessonResponse(
+    Guid Id,
+    Guid LearningPlanId,
+    int WeekNumber,
+    string WeeklyFocus,
+    string TargetDifficulty,
+    string Status,
+    DateTime CreatedAtUtc);

--- a/src/EnglishSeedEngine.Api/Controllers/LearningPlansController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/LearningPlansController.cs
@@ -1,5 +1,6 @@
 using EnglishSeedEngine.Api.Contracts.LearningPlans;
 using EnglishSeedEngine.Application.LearningPlans;
+using EnglishSeedEngine.Application.Lessons;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EnglishSeedEngine.Api.Controllers;
@@ -8,10 +9,14 @@ namespace EnglishSeedEngine.Api.Controllers;
 public sealed class LearningPlansController : ControllerBase
 {
     private readonly ILearningPlanService _learningPlanService;
+    private readonly ILessonService _lessonService;
 
-    public LearningPlansController(ILearningPlanService learningPlanService)
+    public LearningPlansController(
+        ILearningPlanService learningPlanService,
+        ILessonService lessonService)
     {
         _learningPlanService = learningPlanService;
+        _lessonService = lessonService;
     }
 
     [HttpPost("students/{id:guid}/learning-plans")]
@@ -53,6 +58,34 @@ public sealed class LearningPlansController : ControllerBase
         }
 
         return Ok(ToResponse(learningPlan));
+    }
+
+    [HttpPost("learning-plans/{id:guid}/lessons:next")]
+    public async Task<IActionResult> CreateNextLesson([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var lesson = await _lessonService.CreateNextAsync(id, cancellationToken);
+
+            if (lesson is null)
+            {
+                return NotFound();
+            }
+
+            return CreatedAtRoute(
+                LessonsController.RouteNames.GetLessonById,
+                new { id = lesson.Id },
+                LessonsController.ToResponse(lesson));
+        }
+        catch (LearningPlanCompletedException ex)
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "Learning plan completed",
+                Detail = ex.Message,
+                Status = StatusCodes.Status409Conflict
+            });
+        }
     }
 
     private static LearningPlanResponse ToResponse(Domain.LearningPlans.LearningPlan learningPlan)

--- a/src/EnglishSeedEngine.Api/Controllers/LessonsController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/LessonsController.cs
@@ -1,0 +1,46 @@
+using EnglishSeedEngine.Api.Contracts.Lessons;
+using EnglishSeedEngine.Application.Lessons;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EnglishSeedEngine.Api.Controllers;
+
+[ApiController]
+public sealed class LessonsController : ControllerBase
+{
+    private readonly ILessonService _lessonService;
+
+    public LessonsController(ILessonService lessonService)
+    {
+        _lessonService = lessonService;
+    }
+
+    [HttpGet("lessons/{id:guid}", Name = RouteNames.GetLessonById)]
+    public async Task<IActionResult> GetLessonById([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        var lesson = await _lessonService.GetByIdAsync(id, cancellationToken);
+
+        if (lesson is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ToResponse(lesson));
+    }
+
+    internal static LessonResponse ToResponse(Domain.Lessons.Lesson lesson)
+    {
+        return new LessonResponse(
+            lesson.Id,
+            lesson.LearningPlanId,
+            lesson.WeekNumber,
+            lesson.WeeklyFocus,
+            lesson.TargetDifficulty,
+            lesson.Status,
+            lesson.CreatedAtUtc);
+    }
+
+    internal static class RouteNames
+    {
+        public const string GetLessonById = nameof(GetLessonById);
+    }
+}

--- a/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
+++ b/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
@@ -1,6 +1,7 @@
 @EnglishSeedEngine.Api_HostAddress = http://localhost:5042
 @studentId = 00000000-0000-0000-0000-000000000001
 @learningPlanId = 00000000-0000-0000-0000-000000000002
+@lessonId = 00000000-0000-0000-0000-000000000003
 
 GET {{EnglishSeedEngine.Api_HostAddress}}/health
 Accept: application/json
@@ -39,6 +40,15 @@ POST {{EnglishSeedEngine.Api_HostAddress}}/students/{{studentId}}/learning-plans
 ###
 
 GET {{EnglishSeedEngine.Api_HostAddress}}/learning-plans/{{learningPlanId}}
+Accept: application/json
+
+###
+
+POST {{EnglishSeedEngine.Api_HostAddress}}/learning-plans/{{learningPlanId}}/lessons:next
+
+###
+
+GET {{EnglishSeedEngine.Api_HostAddress}}/lessons/{{lessonId}}
 Accept: application/json
 
 ###

--- a/src/EnglishSeedEngine.Api/Program.cs
+++ b/src/EnglishSeedEngine.Api/Program.cs
@@ -1,4 +1,5 @@
 using EnglishSeedEngine.Application.LearningPlans;
+using EnglishSeedEngine.Application.Lessons;
 using EnglishSeedEngine.Application.Students;
 using EnglishSeedEngine.Infrastructure;
 using EnglishSeedEngine.Infrastructure.Persistence;
@@ -12,6 +13,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddHealthChecks();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<ILearningPlanService, LearningPlanService>();
+builder.Services.AddScoped<ILessonService, LessonService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddInfrastructure(builder.Configuration);
 

--- a/src/EnglishSeedEngine.Application/LearningPlans/ILearningPlanRepository.cs
+++ b/src/EnglishSeedEngine.Application/LearningPlans/ILearningPlanRepository.cs
@@ -7,4 +7,6 @@ public interface ILearningPlanRepository
     Task AddAsync(LearningPlan learningPlan, CancellationToken cancellationToken);
 
     Task<LearningPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    Task UpdateAsync(LearningPlan learningPlan, CancellationToken cancellationToken);
 }

--- a/src/EnglishSeedEngine.Application/Lessons/ILessonRepository.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/ILessonRepository.cs
@@ -1,0 +1,12 @@
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.Lessons;
+
+public interface ILessonRepository
+{
+    Task AddAsync(Lesson lesson, CancellationToken cancellationToken);
+
+    Task<Lesson?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<int> CountByLearningPlanIdAsync(Guid learningPlanId, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/Lessons/ILessonService.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/ILessonService.cs
@@ -1,0 +1,10 @@
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.Lessons;
+
+public interface ILessonService
+{
+    Task<Lesson?> CreateNextAsync(Guid learningPlanId, CancellationToken cancellationToken);
+
+    Task<Lesson?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/Lessons/LearningPlanCompletedException.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/LearningPlanCompletedException.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Application.Lessons;
+
+public sealed class LearningPlanCompletedException : Exception
+{
+    public LearningPlanCompletedException(Guid learningPlanId)
+        : base($"Learning plan '{learningPlanId}' is already completed.")
+    {
+    }
+}

--- a/src/EnglishSeedEngine.Application/Lessons/LessonService.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/LessonService.cs
@@ -1,0 +1,65 @@
+using EnglishSeedEngine.Application.LearningPlans;
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.Lessons;
+
+public sealed class LessonService : ILessonService
+{
+    private readonly ILessonRepository _lessonRepository;
+    private readonly ILearningPlanRepository _learningPlanRepository;
+    private readonly TimeProvider _timeProvider;
+
+    public LessonService(
+        ILessonRepository lessonRepository,
+        ILearningPlanRepository learningPlanRepository,
+        TimeProvider timeProvider)
+    {
+        _lessonRepository = lessonRepository;
+        _learningPlanRepository = learningPlanRepository;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<Lesson?> CreateNextAsync(Guid learningPlanId, CancellationToken cancellationToken)
+    {
+        var learningPlan = await _learningPlanRepository.GetByIdAsync(learningPlanId, cancellationToken);
+
+        if (learningPlan is null)
+        {
+            return null;
+        }
+
+        var existingLessons = await _lessonRepository.CountByLearningPlanIdAsync(learningPlanId, cancellationToken);
+
+        try
+        {
+            var draft = learningPlan.GetNextLessonDraft(existingLessons);
+
+            var lesson = Lesson.Create(
+                learningPlan.Id,
+                draft.WeekNumber,
+                draft.WeeklyFocus,
+                draft.TargetDifficulty,
+                _timeProvider.GetUtcNow().UtcDateTime);
+
+            await _lessonRepository.AddAsync(lesson, cancellationToken);
+
+            var totalLessons = existingLessons + 1;
+            if (totalLessons >= learningPlan.WeeklyGoals.Count)
+            {
+                learningPlan.MarkCompleted();
+                await _learningPlanRepository.UpdateAsync(learningPlan, cancellationToken);
+            }
+
+            return lesson;
+        }
+        catch (InvalidOperationException)
+        {
+            throw new LearningPlanCompletedException(learningPlanId);
+        }
+    }
+
+    public Task<Lesson?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _lessonRepository.GetByIdAsync(id, cancellationToken);
+    }
+}

--- a/src/EnglishSeedEngine.Domain/LearningPlans/LearningPlan.cs
+++ b/src/EnglishSeedEngine.Domain/LearningPlans/LearningPlan.cs
@@ -21,6 +21,9 @@ public sealed class LearningPlan
         CreatedAtUtc = createdAtUtc;
     }
 
+    private const string ActiveStatus = "Active";
+    private const string CompletedStatus = "Completed";
+
     public Guid Id { get; private set; }
 
     public Guid StudentId { get; private set; }
@@ -71,6 +74,40 @@ public sealed class LearningPlan
         plan.WeeklyGoals = BuildWeeklyGoals(planId, normalizedStartLevel, normalizedTargetLevel);
 
         return plan;
+    }
+
+    public NextLessonDraft GetNextLessonDraft(int existingLessonsCount)
+    {
+        if (existingLessonsCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(existingLessonsCount), "Existing lessons count cannot be negative.");
+        }
+
+        if (Status == CompletedStatus || existingLessonsCount >= WeeklyGoals.Count)
+        {
+            throw new InvalidOperationException("Learning plan is completed.");
+        }
+
+        var nextWeekNumber = existingLessonsCount + 1;
+        var nextWeeklyGoal = WeeklyGoals.Single(x => x.WeekNumber == nextWeekNumber);
+        var targetDifficulty = nextWeekNumber switch
+        {
+            1 => "Easy",
+            2 => "Medium",
+            3 => "Medium",
+            4 => "Hard",
+            _ => "Hard"
+        };
+
+        return new NextLessonDraft(
+            nextWeekNumber,
+            nextWeeklyGoal.Goal,
+            targetDifficulty);
+    }
+
+    public void MarkCompleted()
+    {
+        Status = CompletedStatus;
     }
 
     private static List<LearningPlanWeeklyGoal> BuildWeeklyGoals(

--- a/src/EnglishSeedEngine.Domain/LearningPlans/NextLessonDraft.cs
+++ b/src/EnglishSeedEngine.Domain/LearningPlans/NextLessonDraft.cs
@@ -1,0 +1,6 @@
+namespace EnglishSeedEngine.Domain.LearningPlans;
+
+public sealed record NextLessonDraft(
+    int WeekNumber,
+    string WeeklyFocus,
+    string TargetDifficulty);

--- a/src/EnglishSeedEngine.Domain/Lessons/Lesson.cs
+++ b/src/EnglishSeedEngine.Domain/Lessons/Lesson.cs
@@ -1,0 +1,87 @@
+namespace EnglishSeedEngine.Domain.Lessons;
+
+public sealed class Lesson
+{
+    private Lesson()
+    {
+    }
+
+    private Lesson(
+        Guid id,
+        Guid learningPlanId,
+        int weekNumber,
+        string weeklyFocus,
+        string targetDifficulty,
+        DateTime createdAtUtc)
+    {
+        Id = id;
+        LearningPlanId = learningPlanId;
+        WeekNumber = weekNumber;
+        WeeklyFocus = weeklyFocus;
+        TargetDifficulty = targetDifficulty;
+        Status = "Draft";
+        CreatedAtUtc = createdAtUtc;
+    }
+
+    public Guid Id { get; private set; }
+
+    public Guid LearningPlanId { get; private set; }
+
+    public int WeekNumber { get; private set; }
+
+    public string WeeklyFocus { get; private set; } = string.Empty;
+
+    public string TargetDifficulty { get; private set; } = string.Empty;
+
+    public string Status { get; private set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; private set; }
+
+    public static Lesson Create(
+        Guid learningPlanId,
+        int weekNumber,
+        string weeklyFocus,
+        string targetDifficulty,
+        DateTime createdAtUtc)
+    {
+        if (learningPlanId == Guid.Empty)
+        {
+            throw new ArgumentException("Learning plan id is required.", nameof(learningPlanId));
+        }
+
+        if (weekNumber is < 1 or > 4)
+        {
+            throw new ArgumentOutOfRangeException(nameof(weekNumber), "Week number must be between 1 and 4.");
+        }
+
+        if (string.IsNullOrWhiteSpace(weeklyFocus))
+        {
+            throw new ArgumentException("Weekly focus is required.", nameof(weeklyFocus));
+        }
+
+        if (string.IsNullOrWhiteSpace(targetDifficulty))
+        {
+            throw new ArgumentException("Target difficulty is required.", nameof(targetDifficulty));
+        }
+
+        var normalizedCreatedAt = NormalizeUtc(createdAtUtc);
+
+        return new Lesson(
+            Guid.NewGuid(),
+            learningPlanId,
+            weekNumber,
+            weeklyFocus.Trim(),
+            targetDifficulty.Trim(),
+            normalizedCreatedAt);
+    }
+
+    private static DateTime NormalizeUtc(DateTime value)
+    {
+        var utcValue = value.Kind == DateTimeKind.Utc
+            ? value
+            : value.ToUniversalTime();
+
+        var truncatedTicks = utcValue.Ticks - (utcValue.Ticks % TimeSpan.TicksPerMicrosecond);
+        return new DateTime(truncatedTicks, DateTimeKind.Utc);
+    }
+}

--- a/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
+++ b/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using EnglishSeedEngine.Application.LearningPlans;
+using EnglishSeedEngine.Application.Lessons;
 using EnglishSeedEngine.Application.Students;
 using EnglishSeedEngine.Infrastructure.Persistence;
 using EnglishSeedEngine.Infrastructure.Persistence.Repositories;
@@ -22,6 +23,7 @@ public static class DependencyInjection
         services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
         services.AddScoped<IStudentRepository, StudentRepository>();
         services.AddScoped<ILearningPlanRepository, LearningPlanRepository>();
+        services.AddScoped<ILessonRepository, LessonRepository>();
 
         return services;
     }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
@@ -1,4 +1,5 @@
 using EnglishSeedEngine.Domain.LearningPlans;
+using EnglishSeedEngine.Domain.Lessons;
 using EnglishSeedEngine.Domain.Students;
 using Microsoft.EntityFrameworkCore;
 
@@ -14,6 +15,8 @@ public sealed class AppDbContext : DbContext
     public DbSet<Student> Students => Set<Student>();
 
     public DbSet<LearningPlan> LearningPlans => Set<LearningPlan>();
+
+    public DbSet<Lesson> Lessons => Set<Lesson>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -48,5 +51,16 @@ public sealed class AppDbContext : DbContext
         weeklyGoal.HasKey(x => x.Id);
         weeklyGoal.Property(x => x.WeekNumber).IsRequired();
         weeklyGoal.Property(x => x.Goal).HasMaxLength(300).IsRequired();
+
+        var lesson = modelBuilder.Entity<Lesson>();
+        lesson.ToTable("lessons");
+        lesson.HasKey(x => x.Id);
+        lesson.Property(x => x.LearningPlanId).IsRequired();
+        lesson.Property(x => x.WeekNumber).IsRequired();
+        lesson.Property(x => x.WeeklyFocus).HasMaxLength(300).IsRequired();
+        lesson.Property(x => x.TargetDifficulty).HasMaxLength(24).IsRequired();
+        lesson.Property(x => x.Status).HasMaxLength(24).IsRequired();
+        lesson.Property(x => x.CreatedAtUtc).IsRequired();
+        lesson.HasIndex(x => x.LearningPlanId);
     }
 }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LearningPlanRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LearningPlanRepository.cs
@@ -26,4 +26,11 @@ public sealed class LearningPlanRepository : ILearningPlanRepository
             .Include(x => x.WeeklyGoals)
             .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
     }
+
+    public async Task UpdateAsync(LearningPlan learningPlan, CancellationToken cancellationToken)
+    {
+        _dbContext.Attach(learningPlan);
+        _dbContext.Entry(learningPlan).Property(x => x.Status).IsModified = true;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LessonRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LessonRepository.cs
@@ -1,0 +1,35 @@
+using EnglishSeedEngine.Application.Lessons;
+using EnglishSeedEngine.Domain.Lessons;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnglishSeedEngine.Infrastructure.Persistence.Repositories;
+
+public sealed class LessonRepository : ILessonRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public LessonRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(Lesson lesson, CancellationToken cancellationToken)
+    {
+        await _dbContext.Lessons.AddAsync(lesson, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<Lesson?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Lessons
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+
+    public Task<int> CountByLearningPlanIdAsync(Guid learningPlanId, CancellationToken cancellationToken)
+    {
+        return _dbContext.Lessons
+            .AsNoTracking()
+            .CountAsync(x => x.LearningPlanId == learningPlanId, cancellationToken);
+    }
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/Lessons/LessonGenerationEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Lessons/LessonGenerationEndpointsTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Json;
+using EnglishSeedEngine.Api.Contracts.LearningPlans;
+using EnglishSeedEngine.Api.Contracts.Lessons;
+using EnglishSeedEngine.Api.Contracts.Students;
+using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.IntegrationTests.Lessons;
+
+[Collection(ApiTestCollection.Name)]
+public sealed class LessonGenerationEndpointsTests : ApiTestBase
+{
+    public LessonGenerationEndpointsTests(ApiIntegrationTestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreateNextLesson_Returns201()
+    {
+        var plan = await CreateLearningPlanAsync();
+
+        var createResponse = await Client.PostAsync($"/learning-plans/{plan.Id}/lessons:next", content: null);
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        createResponse.Headers.Location.Should().NotBeNull();
+
+        var createdLesson = await createResponse.Content.ReadFromJsonAsync<LessonResponse>();
+        createdLesson.Should().NotBeNull();
+        createdLesson!.LearningPlanId.Should().Be(plan.Id);
+        createdLesson.WeekNumber.Should().Be(1);
+        createdLesson.TargetDifficulty.Should().Be("Easy");
+        createdLesson.WeeklyFocus.Should().NotBeNullOrWhiteSpace();
+        createdLesson.Status.Should().Be("Draft");
+        createdLesson.CreatedAtUtc.Should().NotBe(default);
+
+        var getResponse = await Client.GetAsync($"/lessons/{createdLesson.Id}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var persistedLesson = await getResponse.Content.ReadFromJsonAsync<LessonResponse>();
+        persistedLesson.Should().NotBeNull();
+        persistedLesson.Should().BeEquivalentTo(createdLesson);
+    }
+
+    [Fact]
+    public async Task CreateNextLesson_PlanCompleted_Returns409()
+    {
+        var plan = await CreateLearningPlanAsync();
+
+        for (var i = 0; i < 4; i++)
+        {
+            var response = await Client.PostAsync($"/learning-plans/{plan.Id}/lessons:next", content: null);
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        var completedResponse = await Client.PostAsync($"/learning-plans/{plan.Id}/lessons:next", content: null);
+
+        completedResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        var refreshedPlanResponse = await Client.GetAsync($"/learning-plans/{plan.Id}");
+        refreshedPlanResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var refreshedPlan = await refreshedPlanResponse.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        refreshedPlan.Should().NotBeNull();
+        refreshedPlan!.Status.Should().Be("Completed");
+    }
+
+    [Fact]
+    public async Task CreateNextLesson_PlanNotFound_Returns404()
+    {
+        var response = await Client.PostAsync($"/learning-plans/{Guid.NewGuid()}/lessons:next", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task<LearningPlanResponse> CreateLearningPlanAsync()
+    {
+        var student = await CreateStudentAsync();
+        await SubmitInitialAssessmentAsync(student.Id, 6, 10);
+
+        var response = await Client.PostAsync($"/students/{student.Id}/learning-plans", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var plan = await response.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        plan.Should().NotBeNull();
+
+        return plan!;
+    }
+
+    private async Task<StudentResponse> CreateStudentAsync()
+    {
+        var request = new CreateStudentRequest
+        {
+            FullName = "Lesson Student",
+            Age = 12,
+            TutorEmail = $"parent.lesson.{Guid.NewGuid():N}@example.com",
+            TargetLevel = "B1"
+        };
+
+        var response = await Client.PostAsJsonAsync("/students", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var student = await response.Content.ReadFromJsonAsync<StudentResponse>();
+        student.Should().NotBeNull();
+
+        return student!;
+    }
+
+    private async Task SubmitInitialAssessmentAsync(Guid studentId, int correctAnswers, int totalQuestions)
+    {
+        var request = new SubmitInitialAssessmentRequest
+        {
+            CorrectAnswers = correctAnswers,
+            TotalQuestions = totalQuestions
+        };
+
+        var response = await Client.PostAsJsonAsync($"/students/{studentId}/assessments/initial", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}

--- a/tests/EnglishSeedEngine.UnitTests/Students/LearningPlanTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/Students/LearningPlanTests.cs
@@ -33,6 +33,58 @@ public sealed class LearningPlanTests
     }
 
     [Theory]
+    [InlineData(0, 1, "Easy")]
+    [InlineData(1, 2, "Medium")]
+    [InlineData(2, 3, "Medium")]
+    [InlineData(3, 4, "Hard")]
+    public void GetNextLessonDraft_ReturnsExpectedWeekAndDifficulty(
+        int existingLessons,
+        int expectedWeek,
+        string expectedDifficulty)
+    {
+        var plan = LearningPlan.Create(
+            Guid.NewGuid(),
+            "A2",
+            "B1",
+            DateTime.UtcNow);
+
+        var draft = plan.GetNextLessonDraft(existingLessons);
+
+        draft.WeekNumber.Should().Be(expectedWeek);
+        draft.TargetDifficulty.Should().Be(expectedDifficulty);
+        draft.WeeklyFocus.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void GetNextLessonDraft_WhenPlanIsCompleted_ThrowsInvalidOperationException()
+    {
+        var plan = LearningPlan.Create(
+            Guid.NewGuid(),
+            "A2",
+            "B1",
+            DateTime.UtcNow);
+        plan.MarkCompleted();
+
+        var action = () => plan.GetNextLessonDraft(0);
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GetNextLessonDraft_WhenAllLessonsAlreadyGenerated_ThrowsInvalidOperationException()
+    {
+        var plan = LearningPlan.Create(
+            Guid.NewGuid(),
+            "A2",
+            "B1",
+            DateTime.UtcNow);
+
+        var action = () => plan.GetNextLessonDraft(4);
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("   ")]
     public void Create_WithInvalidStartLevel_ThrowsArgumentException(string invalidStartLevel)


### PR DESCRIPTION
## Summary
- add lesson domain/application/infrastructure layers to generate and store next lesson drafts from an active learning plan
- expose POST /learning-plans/{id}/lessons:next and GET /lessons/{id} endpoints with proper 201/404/409 behavior
- extend unit and integration coverage for next-lesson rules and end-to-end API behavior

## Testing
- dotnet test --no-restore

Closes #7