### PR TITLE
feat: generate and version lesson materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 - Initial assessment and CEFR approximation endpoints.
 - Personalized 4-week learning plan endpoints.
 - Next lesson generation and lesson retrieval endpoints.
+- Lesson materials generation (versioned) and retrieval endpoints.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 

--- a/src/EnglishSeedEngine.Api/Contracts/Lessons/LessonMaterialExerciseResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Lessons/LessonMaterialExerciseResponse.cs
@@ -1,0 +1,6 @@
+namespace EnglishSeedEngine.Api.Contracts.Lessons;
+
+public sealed record LessonMaterialExerciseResponse(
+    string Type,
+    string Prompt,
+    string ExpectedAnswer);

--- a/src/EnglishSeedEngine.Api/Contracts/Lessons/LessonMaterialResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Lessons/LessonMaterialResponse.cs
@@ -1,0 +1,10 @@
+namespace EnglishSeedEngine.Api.Contracts.Lessons;
+
+public sealed record LessonMaterialResponse(
+    Guid Id,
+    Guid LessonId,
+    int Version,
+    DateTime GeneratedAtUtc,
+    IReadOnlyCollection<string> Vocabulary,
+    IReadOnlyCollection<string> Phrases,
+    IReadOnlyCollection<LessonMaterialExerciseResponse> Exercises);

--- a/src/EnglishSeedEngine.Api/Controllers/LessonsController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/LessonsController.cs
@@ -1,4 +1,5 @@
 using EnglishSeedEngine.Api.Contracts.Lessons;
+using EnglishSeedEngine.Application.LessonMaterials;
 using EnglishSeedEngine.Application.Lessons;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,10 +9,14 @@ namespace EnglishSeedEngine.Api.Controllers;
 public sealed class LessonsController : ControllerBase
 {
     private readonly ILessonService _lessonService;
+    private readonly ILessonMaterialService _lessonMaterialService;
 
-    public LessonsController(ILessonService lessonService)
+    public LessonsController(
+        ILessonService lessonService,
+        ILessonMaterialService lessonMaterialService)
     {
         _lessonService = lessonService;
+        _lessonMaterialService = lessonMaterialService;
     }
 
     [HttpGet("lessons/{id:guid}", Name = RouteNames.GetLessonById)]
@@ -27,6 +32,52 @@ public sealed class LessonsController : ControllerBase
         return Ok(ToResponse(lesson));
     }
 
+    [HttpPost("lessons/{id:guid}/materials:generate")]
+    public async Task<IActionResult> GenerateLessonMaterials([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var lessonMaterial = await _lessonMaterialService.GenerateAsync(id, cancellationToken);
+
+            if (lessonMaterial is null)
+            {
+                return NotFound();
+            }
+
+            return CreatedAtRoute(
+                RouteNames.GetLessonMaterialsByLessonId,
+                new { id },
+                ToMaterialResponse(lessonMaterial));
+        }
+        catch (AiProviderUnavailableException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new ProblemDetails
+            {
+                Title = "Lesson material generation unavailable",
+                Detail = ex.Message,
+                Status = StatusCodes.Status503ServiceUnavailable
+            });
+        }
+    }
+
+    [HttpGet("lessons/{id:guid}/materials", Name = RouteNames.GetLessonMaterialsByLessonId)]
+    public async Task<IActionResult> GetLessonMaterialsByLessonId([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        var lessonMaterials = await _lessonMaterialService.GetByLessonIdAsync(id, cancellationToken);
+
+        if (lessonMaterials is null)
+        {
+            return NotFound();
+        }
+
+        var response = lessonMaterials
+            .OrderByDescending(x => x.Version)
+            .Select(ToMaterialResponse)
+            .ToArray();
+
+        return Ok(response);
+    }
+
     internal static LessonResponse ToResponse(Domain.Lessons.Lesson lesson)
     {
         return new LessonResponse(
@@ -39,8 +90,24 @@ public sealed class LessonsController : ControllerBase
             lesson.CreatedAtUtc);
     }
 
+    internal static LessonMaterialResponse ToMaterialResponse(Domain.Lessons.LessonMaterial lessonMaterial)
+    {
+        return new LessonMaterialResponse(
+            lessonMaterial.Id,
+            lessonMaterial.LessonId,
+            lessonMaterial.Version,
+            lessonMaterial.GeneratedAtUtc,
+            lessonMaterial.Vocabulary,
+            lessonMaterial.Phrases,
+            lessonMaterial.Exercises
+                .Select(x => new LessonMaterialExerciseResponse(x.Type, x.Prompt, x.ExpectedAnswer))
+                .ToArray());
+    }
+
     internal static class RouteNames
     {
         public const string GetLessonById = nameof(GetLessonById);
+
+        public const string GetLessonMaterialsByLessonId = nameof(GetLessonMaterialsByLessonId);
     }
 }

--- a/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
+++ b/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
@@ -52,3 +52,12 @@ GET {{EnglishSeedEngine.Api_HostAddress}}/lessons/{{lessonId}}
 Accept: application/json
 
 ###
+
+POST {{EnglishSeedEngine.Api_HostAddress}}/lessons/{{lessonId}}/materials:generate
+
+###
+
+GET {{EnglishSeedEngine.Api_HostAddress}}/lessons/{{lessonId}}/materials
+Accept: application/json
+
+###

--- a/src/EnglishSeedEngine.Api/Program.cs
+++ b/src/EnglishSeedEngine.Api/Program.cs
@@ -1,4 +1,5 @@
 using EnglishSeedEngine.Application.LearningPlans;
+using EnglishSeedEngine.Application.LessonMaterials;
 using EnglishSeedEngine.Application.Lessons;
 using EnglishSeedEngine.Application.Students;
 using EnglishSeedEngine.Infrastructure;
@@ -13,6 +14,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddHealthChecks();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<ILearningPlanService, LearningPlanService>();
+builder.Services.AddScoped<ILessonMaterialService, LessonMaterialService>();
 builder.Services.AddScoped<ILessonService, LessonService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddInfrastructure(builder.Configuration);

--- a/src/EnglishSeedEngine.Application/EnglishSeedEngine.Application.csproj
+++ b/src/EnglishSeedEngine.Application/EnglishSeedEngine.Application.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\EnglishSeedEngine.Domain\EnglishSeedEngine.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/EnglishSeedEngine.Application/LessonMaterials/AiProviderUnavailableException.cs
+++ b/src/EnglishSeedEngine.Application/LessonMaterials/AiProviderUnavailableException.cs
@@ -1,0 +1,14 @@
+namespace EnglishSeedEngine.Application.LessonMaterials;
+
+public sealed class AiProviderUnavailableException : Exception
+{
+    public AiProviderUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    public AiProviderUnavailableException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/EnglishSeedEngine.Application/LessonMaterials/GeneratedLessonMaterials.cs
+++ b/src/EnglishSeedEngine.Application/LessonMaterials/GeneratedLessonMaterials.cs
@@ -1,0 +1,11 @@
+namespace EnglishSeedEngine.Application.LessonMaterials;
+
+public sealed record GeneratedLessonMaterials(
+    IReadOnlyCollection<string> Vocabulary,
+    IReadOnlyCollection<string> Phrases,
+    IReadOnlyCollection<GeneratedLessonExercise> Exercises);
+
+public sealed record GeneratedLessonExercise(
+    string Type,
+    string Prompt,
+    string ExpectedAnswer);

--- a/src/EnglishSeedEngine.Application/LessonMaterials/ILessonMaterialGenerator.cs
+++ b/src/EnglishSeedEngine.Application/LessonMaterials/ILessonMaterialGenerator.cs
@@ -1,0 +1,8 @@
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.LessonMaterials;
+
+public interface ILessonMaterialGenerator
+{
+    Task<GeneratedLessonMaterials> GenerateAsync(Lesson lesson, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/LessonMaterials/ILessonMaterialRepository.cs
+++ b/src/EnglishSeedEngine.Application/LessonMaterials/ILessonMaterialRepository.cs
@@ -1,0 +1,12 @@
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.LessonMaterials;
+
+public interface ILessonMaterialRepository
+{
+    Task AddAsync(LessonMaterial lessonMaterial, CancellationToken cancellationToken);
+
+    Task<int> GetLatestVersionByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<LessonMaterial>> GetByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/LessonMaterials/ILessonMaterialService.cs
+++ b/src/EnglishSeedEngine.Application/LessonMaterials/ILessonMaterialService.cs
@@ -1,0 +1,10 @@
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.LessonMaterials;
+
+public interface ILessonMaterialService
+{
+    Task<LessonMaterial?> GenerateAsync(Guid lessonId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<LessonMaterial>?> GetByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/LessonMaterials/LessonMaterialService.cs
+++ b/src/EnglishSeedEngine.Application/LessonMaterials/LessonMaterialService.cs
@@ -1,0 +1,84 @@
+using EnglishSeedEngine.Application.Lessons;
+using EnglishSeedEngine.Domain.Lessons;
+using Microsoft.Extensions.Logging;
+
+namespace EnglishSeedEngine.Application.LessonMaterials;
+
+public sealed class LessonMaterialService : ILessonMaterialService
+{
+    private readonly ILessonRepository _lessonRepository;
+    private readonly ILessonMaterialRepository _lessonMaterialRepository;
+    private readonly ILessonMaterialGenerator _lessonMaterialGenerator;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<LessonMaterialService> _logger;
+
+    public LessonMaterialService(
+        ILessonRepository lessonRepository,
+        ILessonMaterialRepository lessonMaterialRepository,
+        ILessonMaterialGenerator lessonMaterialGenerator,
+        TimeProvider timeProvider,
+        ILogger<LessonMaterialService> logger)
+    {
+        _lessonRepository = lessonRepository;
+        _lessonMaterialRepository = lessonMaterialRepository;
+        _lessonMaterialGenerator = lessonMaterialGenerator;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<LessonMaterial?> GenerateAsync(Guid lessonId, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Lesson material generation started for lesson {LessonId}", lessonId);
+
+        var lesson = await _lessonRepository.GetByIdAsync(lessonId, cancellationToken);
+
+        if (lesson is null)
+        {
+            _logger.LogWarning("Lesson material generation skipped because lesson {LessonId} was not found", lessonId);
+            return null;
+        }
+
+        var latestVersion = await _lessonMaterialRepository.GetLatestVersionByLessonIdAsync(lessonId, cancellationToken);
+        var nextVersion = latestVersion + 1;
+
+        try
+        {
+            var generatedMaterials = await _lessonMaterialGenerator.GenerateAsync(lesson, cancellationToken);
+
+            var lessonMaterial = LessonMaterial.Create(
+                lessonId,
+                nextVersion,
+                generatedMaterials.Vocabulary,
+                generatedMaterials.Phrases,
+                generatedMaterials.Exercises
+                    .Select(x => new LessonMaterialExercise(x.Type, x.Prompt, x.ExpectedAnswer))
+                    .ToArray(),
+                _timeProvider.GetUtcNow().UtcDateTime);
+
+            await _lessonMaterialRepository.AddAsync(lessonMaterial, cancellationToken);
+
+            _logger.LogInformation(
+                "Lesson material generation completed for lesson {LessonId} with version {Version}",
+                lessonId,
+                lessonMaterial.Version);
+
+            return lessonMaterial;
+        }
+        catch (AiProviderUnavailableException ex)
+        {
+            _logger.LogError(ex, "Lesson material generation failed due to AI provider outage for lesson {LessonId}", lessonId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyCollection<LessonMaterial>?> GetByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken)
+    {
+        var lesson = await _lessonRepository.GetByIdAsync(lessonId, cancellationToken);
+        if (lesson is null)
+        {
+            return null;
+        }
+
+        return await _lessonMaterialRepository.GetByLessonIdAsync(lessonId, cancellationToken);
+    }
+}

--- a/src/EnglishSeedEngine.Domain/Lessons/LessonMaterial.cs
+++ b/src/EnglishSeedEngine.Domain/Lessons/LessonMaterial.cs
@@ -1,0 +1,196 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+
+namespace EnglishSeedEngine.Domain.Lessons;
+
+public sealed class LessonMaterial
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+    private static readonly string[] RequiredExerciseTypes = ["cloze", "translation", "dictation"];
+
+    private LessonMaterial()
+    {
+    }
+
+    private LessonMaterial(
+        Guid id,
+        Guid lessonId,
+        int version,
+        string vocabularyJson,
+        string phrasesJson,
+        string exercisesJson,
+        DateTime generatedAtUtc)
+    {
+        Id = id;
+        LessonId = lessonId;
+        Version = version;
+        VocabularyJson = vocabularyJson;
+        PhrasesJson = phrasesJson;
+        ExercisesJson = exercisesJson;
+        GeneratedAtUtc = generatedAtUtc;
+    }
+
+    public Guid Id { get; private set; }
+
+    public Guid LessonId { get; private set; }
+
+    public int Version { get; private set; }
+
+    public string VocabularyJson { get; private set; } = "[]";
+
+    public string PhrasesJson { get; private set; } = "[]";
+
+    public string ExercisesJson { get; private set; } = "[]";
+
+    public DateTime GeneratedAtUtc { get; private set; }
+
+    [NotMapped]
+    public IReadOnlyCollection<string> Vocabulary => DeserializeStringCollection(VocabularyJson);
+
+    [NotMapped]
+    public IReadOnlyCollection<string> Phrases => DeserializeStringCollection(PhrasesJson);
+
+    [NotMapped]
+    public IReadOnlyCollection<LessonMaterialExercise> Exercises => DeserializeExerciseCollection(ExercisesJson);
+
+    public static LessonMaterial Create(
+        Guid lessonId,
+        int version,
+        IReadOnlyCollection<string> vocabulary,
+        IReadOnlyCollection<string> phrases,
+        IReadOnlyCollection<LessonMaterialExercise> exercises,
+        DateTime generatedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(vocabulary);
+        ArgumentNullException.ThrowIfNull(phrases);
+        ArgumentNullException.ThrowIfNull(exercises);
+
+        if (lessonId == Guid.Empty)
+        {
+            throw new ArgumentException("Lesson id is required.", nameof(lessonId));
+        }
+
+        if (version < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version), "Version must be greater than zero.");
+        }
+
+        var normalizedVocabulary = NormalizeValues(vocabulary, nameof(vocabulary), "Vocabulary");
+        var normalizedPhrases = NormalizeValues(phrases, nameof(phrases), "Phrases");
+        var normalizedExercises = NormalizeExercises(exercises);
+        ValidateRequiredExerciseTypes(normalizedExercises);
+
+        var normalizedGeneratedAt = NormalizeUtc(generatedAtUtc);
+
+        return new LessonMaterial(
+            Guid.NewGuid(),
+            lessonId,
+            version,
+            JsonSerializer.Serialize(normalizedVocabulary, JsonSerializerOptions),
+            JsonSerializer.Serialize(normalizedPhrases, JsonSerializerOptions),
+            JsonSerializer.Serialize(normalizedExercises, JsonSerializerOptions),
+            normalizedGeneratedAt);
+    }
+
+    private static string[] NormalizeValues(
+        IReadOnlyCollection<string> values,
+        string paramName,
+        string label)
+    {
+        if (values.Count == 0)
+        {
+            throw new ArgumentException($"{label} cannot be empty.", paramName);
+        }
+
+        var normalized = values
+            .Select(x => x?.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x!)
+            .ToArray();
+
+        if (normalized.Length == 0)
+        {
+            throw new ArgumentException($"{label} cannot be empty.", paramName);
+        }
+
+        return normalized;
+    }
+
+    private static LessonMaterialExercise[] NormalizeExercises(IReadOnlyCollection<LessonMaterialExercise> exercises)
+    {
+        if (exercises.Count == 0)
+        {
+            throw new ArgumentException("Exercises cannot be empty.", nameof(exercises));
+        }
+
+        var normalized = new List<LessonMaterialExercise>(exercises.Count);
+
+        foreach (var exercise in exercises)
+        {
+            if (exercise is null)
+            {
+                throw new ArgumentException("Exercises cannot contain null elements.", nameof(exercises));
+            }
+
+            var normalizedType = exercise.Type.Trim().ToLowerInvariant();
+            if (string.IsNullOrWhiteSpace(normalizedType))
+            {
+                throw new ArgumentException("Exercise type is required.", nameof(exercises));
+            }
+
+            var prompt = exercise.Prompt.Trim();
+            if (string.IsNullOrWhiteSpace(prompt))
+            {
+                throw new ArgumentException("Exercise prompt is required.", nameof(exercises));
+            }
+
+            var expectedAnswer = exercise.ExpectedAnswer.Trim();
+            if (string.IsNullOrWhiteSpace(expectedAnswer))
+            {
+                throw new ArgumentException("Exercise expected answer is required.", nameof(exercises));
+            }
+
+            normalized.Add(new LessonMaterialExercise(normalizedType, prompt, expectedAnswer));
+        }
+
+        return normalized.ToArray();
+    }
+
+    private static void ValidateRequiredExerciseTypes(IReadOnlyCollection<LessonMaterialExercise> exercises)
+    {
+        var normalizedTypes = exercises
+            .Select(x => x.Type)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var missingTypes = RequiredExerciseTypes
+            .Where(x => !normalizedTypes.Contains(x))
+            .ToArray();
+
+        if (missingTypes.Length > 0)
+        {
+            throw new ArgumentException(
+                $"Exercises must include required types: {string.Join(", ", RequiredExerciseTypes)}.",
+                nameof(exercises));
+        }
+    }
+
+    private static IReadOnlyCollection<string> DeserializeStringCollection(string json)
+    {
+        return JsonSerializer.Deserialize<string[]>(json, JsonSerializerOptions) ?? [];
+    }
+
+    private static IReadOnlyCollection<LessonMaterialExercise> DeserializeExerciseCollection(string json)
+    {
+        return JsonSerializer.Deserialize<LessonMaterialExercise[]>(json, JsonSerializerOptions) ?? [];
+    }
+
+    private static DateTime NormalizeUtc(DateTime value)
+    {
+        var utcValue = value.Kind == DateTimeKind.Utc
+            ? value
+            : value.ToUniversalTime();
+
+        var truncatedTicks = utcValue.Ticks - (utcValue.Ticks % TimeSpan.TicksPerMicrosecond);
+        return new DateTime(truncatedTicks, DateTimeKind.Utc);
+    }
+}

--- a/src/EnglishSeedEngine.Domain/Lessons/LessonMaterialExercise.cs
+++ b/src/EnglishSeedEngine.Domain/Lessons/LessonMaterialExercise.cs
@@ -1,0 +1,6 @@
+namespace EnglishSeedEngine.Domain.Lessons;
+
+public sealed record LessonMaterialExercise(
+    string Type,
+    string Prompt,
+    string ExpectedAnswer);

--- a/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
+++ b/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,8 @@
 using EnglishSeedEngine.Application.LearningPlans;
+using EnglishSeedEngine.Application.LessonMaterials;
 using EnglishSeedEngine.Application.Lessons;
 using EnglishSeedEngine.Application.Students;
+using EnglishSeedEngine.Infrastructure.LessonMaterials;
 using EnglishSeedEngine.Infrastructure.Persistence;
 using EnglishSeedEngine.Infrastructure.Persistence.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -24,6 +26,8 @@ public static class DependencyInjection
         services.AddScoped<IStudentRepository, StudentRepository>();
         services.AddScoped<ILearningPlanRepository, LearningPlanRepository>();
         services.AddScoped<ILessonRepository, LessonRepository>();
+        services.AddScoped<ILessonMaterialRepository, LessonMaterialRepository>();
+        services.AddScoped<ILessonMaterialGenerator, TemplateLessonMaterialGenerator>();
 
         return services;
     }

--- a/src/EnglishSeedEngine.Infrastructure/EnglishSeedEngine.Infrastructure.csproj
+++ b/src/EnglishSeedEngine.Infrastructure/EnglishSeedEngine.Infrastructure.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
   </ItemGroup>
 

--- a/src/EnglishSeedEngine.Infrastructure/LessonMaterials/TemplateLessonMaterialGenerator.cs
+++ b/src/EnglishSeedEngine.Infrastructure/LessonMaterials/TemplateLessonMaterialGenerator.cs
@@ -1,0 +1,44 @@
+using EnglishSeedEngine.Application.LessonMaterials;
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Infrastructure.LessonMaterials;
+
+public sealed class TemplateLessonMaterialGenerator : ILessonMaterialGenerator
+{
+    public Task<GeneratedLessonMaterials> GenerateAsync(Lesson lesson, CancellationToken cancellationToken)
+    {
+        var focus = lesson.WeeklyFocus;
+        var difficulty = lesson.TargetDifficulty;
+
+        var vocabulary = new[]
+        {
+            $"{focus} - key verb",
+            $"{focus} - key noun",
+            $"{focus} - daily expression"
+        };
+
+        var phrases = new[]
+        {
+            $"I can explain {focus.ToLowerInvariant()} in simple sentences.",
+            $"This {difficulty.ToLowerInvariant()} exercise helps me practice {focus.ToLowerInvariant()}."
+        };
+
+        var exercises = new[]
+        {
+            new GeneratedLessonExercise(
+                "cloze",
+                $"Complete the sentence: I usually ____ when we practice {focus.ToLowerInvariant()}.",
+                "review"),
+            new GeneratedLessonExercise(
+                "translation",
+                $"Translate into English: \"Esta semana practico {focus.ToLowerInvariant()}.\"",
+                $"This week I practice {focus.ToLowerInvariant()}."),
+            new GeneratedLessonExercise(
+                "dictation",
+                $"Write exactly: \"{focus} builds confidence every day.\"",
+                $"{focus} builds confidence every day.")
+        };
+
+        return Task.FromResult(new GeneratedLessonMaterials(vocabulary, phrases, exercises));
+    }
+}

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
@@ -18,6 +18,8 @@ public sealed class AppDbContext : DbContext
 
     public DbSet<Lesson> Lessons => Set<Lesson>();
 
+    public DbSet<LessonMaterial> LessonMaterials => Set<LessonMaterial>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         var student = modelBuilder.Entity<Student>();
@@ -62,5 +64,17 @@ public sealed class AppDbContext : DbContext
         lesson.Property(x => x.Status).HasMaxLength(24).IsRequired();
         lesson.Property(x => x.CreatedAtUtc).IsRequired();
         lesson.HasIndex(x => x.LearningPlanId);
+
+        var lessonMaterial = modelBuilder.Entity<LessonMaterial>();
+        lessonMaterial.ToTable("lesson_materials");
+        lessonMaterial.HasKey(x => x.Id);
+        lessonMaterial.Property(x => x.LessonId).IsRequired();
+        lessonMaterial.Property(x => x.Version).IsRequired();
+        lessonMaterial.Property(x => x.VocabularyJson).HasColumnType("jsonb").IsRequired();
+        lessonMaterial.Property(x => x.PhrasesJson).HasColumnType("jsonb").IsRequired();
+        lessonMaterial.Property(x => x.ExercisesJson).HasColumnType("jsonb").IsRequired();
+        lessonMaterial.Property(x => x.GeneratedAtUtc).IsRequired();
+        lessonMaterial.HasIndex(x => x.LessonId);
+        lessonMaterial.HasIndex(x => new { x.LessonId, x.Version }).IsUnique();
     }
 }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LessonMaterialRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LessonMaterialRepository.cs
@@ -1,0 +1,41 @@
+using EnglishSeedEngine.Application.LessonMaterials;
+using EnglishSeedEngine.Domain.Lessons;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnglishSeedEngine.Infrastructure.Persistence.Repositories;
+
+public sealed class LessonMaterialRepository : ILessonMaterialRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public LessonMaterialRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(LessonMaterial lessonMaterial, CancellationToken cancellationToken)
+    {
+        await _dbContext.LessonMaterials.AddAsync(lessonMaterial, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<int> GetLatestVersionByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken)
+    {
+        var latestVersion = await _dbContext.LessonMaterials
+            .AsNoTracking()
+            .Where(x => x.LessonId == lessonId)
+            .Select(x => (int?)x.Version)
+            .MaxAsync(cancellationToken);
+
+        return latestVersion ?? 0;
+    }
+
+    public async Task<IReadOnlyCollection<LessonMaterial>> GetByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken)
+    {
+        return await _dbContext.LessonMaterials
+            .AsNoTracking()
+            .Where(x => x.LessonId == lessonId)
+            .OrderByDescending(x => x.Version)
+            .ToArrayAsync(cancellationToken);
+    }
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/Lessons/LessonMaterialsEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Lessons/LessonMaterialsEndpointsTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Net.Http.Json;
+using EnglishSeedEngine.Api.Contracts.LearningPlans;
+using EnglishSeedEngine.Api.Contracts.Lessons;
+using EnglishSeedEngine.Api.Contracts.Students;
+using EnglishSeedEngine.Application.LessonMaterials;
+using EnglishSeedEngine.Domain.Lessons;
+using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace EnglishSeedEngine.IntegrationTests.Lessons;
+
+[Collection(ApiTestCollection.Name)]
+public sealed class LessonMaterialsEndpointsTests : ApiTestBase
+{
+    public LessonMaterialsEndpointsTests(ApiIntegrationTestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GenerateMaterials_Returns201()
+    {
+        var lesson = await CreateLessonAsync();
+
+        var firstGenerateResponse = await Client.PostAsync($"/lessons/{lesson.Id}/materials:generate", content: null);
+        firstGenerateResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var firstMaterial = await firstGenerateResponse.Content.ReadFromJsonAsync<LessonMaterialResponse>();
+        firstMaterial.Should().NotBeNull();
+        firstMaterial!.Version.Should().Be(1);
+        firstMaterial.Vocabulary.Should().NotBeEmpty();
+        firstMaterial.Phrases.Should().NotBeEmpty();
+        firstMaterial.Exercises.Should().HaveCount(3);
+        firstMaterial.Exercises.Select(x => x.Type).Should().BeEquivalentTo(["cloze", "translation", "dictation"]);
+
+        var secondGenerateResponse = await Client.PostAsync($"/lessons/{lesson.Id}/materials:generate", content: null);
+        secondGenerateResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var secondMaterial = await secondGenerateResponse.Content.ReadFromJsonAsync<LessonMaterialResponse>();
+        secondMaterial.Should().NotBeNull();
+        secondMaterial!.Version.Should().Be(2);
+
+        var getResponse = await Client.GetAsync($"/lessons/{lesson.Id}/materials");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var materials = await getResponse.Content.ReadFromJsonAsync<LessonMaterialResponse[]>();
+        materials.Should().NotBeNull();
+        materials.Should().HaveCount(2);
+        materials![0].Version.Should().Be(2);
+        materials[1].Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GenerateMaterials_LessonNotFound_Returns404()
+    {
+        var response = await Client.PostAsync($"/lessons/{Guid.NewGuid()}/materials:generate", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GenerateMaterials_AiProviderFailure_Returns503()
+    {
+        var lesson = await CreateLessonAsync();
+
+        using var failingFactory = Fixture.Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll(typeof(ILessonMaterialGenerator));
+                services.AddScoped<ILessonMaterialGenerator, FailingLessonMaterialGenerator>();
+            }));
+
+        using var failingClient = failingFactory.CreateClient();
+
+        var response = await failingClient.PostAsync($"/lessons/{lesson.Id}/materials:generate", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    private async Task<LessonResponse> CreateLessonAsync()
+    {
+        var plan = await CreateLearningPlanAsync();
+
+        var response = await Client.PostAsync($"/learning-plans/{plan.Id}/lessons:next", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var lesson = await response.Content.ReadFromJsonAsync<LessonResponse>();
+        lesson.Should().NotBeNull();
+
+        return lesson!;
+    }
+
+    private async Task<LearningPlanResponse> CreateLearningPlanAsync()
+    {
+        var student = await CreateStudentAsync();
+        await SubmitInitialAssessmentAsync(student.Id, 7, 10);
+
+        var response = await Client.PostAsync($"/students/{student.Id}/learning-plans", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var plan = await response.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        plan.Should().NotBeNull();
+
+        return plan!;
+    }
+
+    private async Task<StudentResponse> CreateStudentAsync()
+    {
+        var request = new CreateStudentRequest
+        {
+            FullName = "Material Student",
+            Age = 11,
+            TutorEmail = $"parent.material.{Guid.NewGuid():N}@example.com",
+            TargetLevel = "B1"
+        };
+
+        var response = await Client.PostAsJsonAsync("/students", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var student = await response.Content.ReadFromJsonAsync<StudentResponse>();
+        student.Should().NotBeNull();
+
+        return student!;
+    }
+
+    private async Task SubmitInitialAssessmentAsync(Guid studentId, int correctAnswers, int totalQuestions)
+    {
+        var request = new SubmitInitialAssessmentRequest
+        {
+            CorrectAnswers = correctAnswers,
+            TotalQuestions = totalQuestions
+        };
+
+        var response = await Client.PostAsJsonAsync($"/students/{studentId}/assessments/initial", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    private sealed class FailingLessonMaterialGenerator : ILessonMaterialGenerator
+    {
+        public Task<GeneratedLessonMaterials> GenerateAsync(Lesson lesson, CancellationToken cancellationToken)
+        {
+            throw new AiProviderUnavailableException("AI provider is temporarily unavailable.");
+        }
+    }
+}

--- a/tests/EnglishSeedEngine.UnitTests/Lessons/LessonMaterialTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/Lessons/LessonMaterialTests.cs
@@ -1,0 +1,72 @@
+using EnglishSeedEngine.Domain.Lessons;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.UnitTests.Lessons;
+
+public sealed class LessonMaterialTests
+{
+    [Fact]
+    public void Create_WithValidPayload_CreatesVersionedMaterial()
+    {
+        var lessonId = Guid.NewGuid();
+        var generatedAtUtc = new DateTime(2026, 4, 26, 16, 0, 0, DateTimeKind.Utc);
+
+        var material = LessonMaterial.Create(
+            lessonId,
+            version: 1,
+            vocabulary: ["greet", "review", "confidence"],
+            phrases: ["I can greet people politely.", "I review vocabulary every day."],
+            exercises:
+            [
+                new LessonMaterialExercise("cloze", "Complete: I ___ every day.", "practice"),
+                new LessonMaterialExercise("translation", "Translate: Practico todos los dias.", "I practice every day."),
+                new LessonMaterialExercise("dictation", "Write: Practice makes progress.", "Practice makes progress.")
+            ],
+            generatedAtUtc);
+
+        material.Id.Should().NotBeEmpty();
+        material.LessonId.Should().Be(lessonId);
+        material.Version.Should().Be(1);
+        material.Vocabulary.Should().Contain("greet");
+        material.Phrases.Should().Contain("I can greet people politely.");
+        material.Exercises.Should().HaveCount(3);
+        material.Exercises.Select(x => x.Type).Should().BeEquivalentTo(["cloze", "translation", "dictation"]);
+    }
+
+    [Fact]
+    public void Create_WithMissingRequiredExerciseType_ThrowsArgumentException()
+    {
+        var action = () => LessonMaterial.Create(
+            Guid.NewGuid(),
+            version: 1,
+            vocabulary: ["practice"],
+            phrases: ["I practice."],
+            exercises:
+            [
+                new LessonMaterialExercise("cloze", "Complete sentence", "practice"),
+                new LessonMaterialExercise("translation", "Translate sentence", "I practice.")
+            ],
+            DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Create_WithInvalidVersion_ThrowsArgumentOutOfRangeException()
+    {
+        var action = () => LessonMaterial.Create(
+            Guid.NewGuid(),
+            version: 0,
+            vocabulary: ["practice"],
+            phrases: ["I practice."],
+            exercises:
+            [
+                new LessonMaterialExercise("cloze", "Complete sentence", "practice"),
+                new LessonMaterialExercise("translation", "Translate sentence", "I practice."),
+                new LessonMaterialExercise("dictation", "Write sentence", "I practice.")
+            ],
+            DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## Summary
- add versioned lesson materials generation for each lesson (vocabulary, phrases, and exercises)
- expose POST /lessons/{id}/materials:generate and GET /lessons/{id}/materials
- map AI provider outage to controlled 503 Service Unavailable response
- add structured logs for generation start/end and provider errors
- extend unit and integration coverage for materials domain rules and API behavior

## Testing
- dotnet test

Closes #8