### PR TITLE
feat: add practice session scoring and weak points

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 - Personalized 4-week learning plan endpoints.
 - Next lesson generation and lesson retrieval endpoints.
 - Lesson materials generation (versioned) and retrieval endpoints.
+- Practice session lifecycle with scoring and weak points endpoints.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 

--- a/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/CreatePracticeSessionRequest.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/CreatePracticeSessionRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EnglishSeedEngine.Api.Contracts.PracticeSessions;
+
+public sealed class CreatePracticeSessionRequest
+{
+    [Required]
+    public Guid LessonId { get; init; }
+}

--- a/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/PracticeSessionResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/PracticeSessionResponse.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Api.Contracts.PracticeSessions;
+
+public sealed record PracticeSessionResponse(
+    Guid Id,
+    Guid LessonId,
+    string Status,
+    int TotalExercises,
+    DateTime CreatedAtUtc,
+    DateTime? FinishedAtUtc);

--- a/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/PracticeSessionResultResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/PracticeSessionResultResponse.cs
@@ -1,0 +1,11 @@
+namespace EnglishSeedEngine.Api.Contracts.PracticeSessions;
+
+public sealed record PracticeSessionResultResponse(
+    Guid PracticeSessionId,
+    string Status,
+    int TotalExercises,
+    int AnsweredExercises,
+    int CorrectAnswers,
+    int ScorePercentage,
+    IReadOnlyCollection<string> WeakPoints,
+    DateTime? FinishedAtUtc);

--- a/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/SubmitPracticeSessionAnswerRequest.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/SubmitPracticeSessionAnswerRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EnglishSeedEngine.Api.Contracts.PracticeSessions;
+
+public sealed class SubmitPracticeSessionAnswerRequest
+{
+    [Range(1, int.MaxValue)]
+    public int ExerciseIndex { get; init; }
+
+    [Required]
+    [MinLength(1)]
+    public string Answer { get; init; } = string.Empty;
+}

--- a/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/SubmitPracticeSessionAnswersRequest.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/PracticeSessions/SubmitPracticeSessionAnswersRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EnglishSeedEngine.Api.Contracts.PracticeSessions;
+
+public sealed class SubmitPracticeSessionAnswersRequest
+{
+    [Required]
+    [MinLength(1)]
+    public IReadOnlyCollection<SubmitPracticeSessionAnswerRequest> Answers { get; init; } = [];
+}

--- a/src/EnglishSeedEngine.Api/Controllers/PracticeSessionsController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/PracticeSessionsController.cs
@@ -1,0 +1,184 @@
+using EnglishSeedEngine.Api.Contracts.PracticeSessions;
+using EnglishSeedEngine.Application.PracticeSessions;
+using EnglishSeedEngine.Domain.PracticeSessions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EnglishSeedEngine.Api.Controllers;
+
+[ApiController]
+public sealed class PracticeSessionsController : ControllerBase
+{
+    private readonly IPracticeSessionService _practiceSessionService;
+
+    public PracticeSessionsController(IPracticeSessionService practiceSessionService)
+    {
+        _practiceSessionService = practiceSessionService;
+    }
+
+    [HttpPost("practice-sessions")]
+    public async Task<IActionResult> StartPracticeSession(
+        [FromBody] CreatePracticeSessionRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var practiceSession = await _practiceSessionService.StartAsync(request.LessonId, cancellationToken);
+
+            if (practiceSession is null)
+            {
+                return NotFound();
+            }
+
+            return CreatedAtRoute(
+                RouteNames.GetPracticeSessionResult,
+                new { id = practiceSession.Id },
+                ToResponse(practiceSession));
+        }
+        catch (LessonMaterialsRequiredException ex)
+        {
+            return UnprocessableEntity(new ProblemDetails
+            {
+                Title = "Lesson materials required",
+                Detail = ex.Message,
+                Status = StatusCodes.Status422UnprocessableEntity
+            });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid practice session payload",
+                Detail = ex.Message,
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+    }
+
+    [HttpPost("practice-sessions/{id:guid}/answers")]
+    public async Task<IActionResult> SubmitAnswers(
+        [FromRoute] Guid id,
+        [FromBody] SubmitPracticeSessionAnswersRequest request,
+        CancellationToken cancellationToken)
+    {
+        var answers = request.Answers
+            .Select(x => new PracticeSessionAnswer(x.ExerciseIndex, x.Answer))
+            .ToArray();
+
+        try
+        {
+            var practiceSession = await _practiceSessionService.SubmitAnswersAsync(id, answers, cancellationToken);
+
+            if (practiceSession is null)
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
+        catch (PracticeSessionFinishedException ex)
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "Practice session already finished",
+                Detail = ex.Message,
+                Status = StatusCodes.Status409Conflict
+            });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid submitted answers",
+                Detail = ex.Message,
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+    }
+
+    [HttpPost("practice-sessions/{id:guid}:finish")]
+    public async Task<IActionResult> FinishPracticeSession([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var practiceSession = await _practiceSessionService.FinishAsync(id, cancellationToken);
+
+            if (practiceSession is null)
+            {
+                return NotFound();
+            }
+
+            var result = practiceSession.GetResult();
+            return Ok(ToResultResponse(practiceSession, result));
+        }
+        catch (PracticeSessionFinishedException ex)
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "Practice session already finished",
+                Detail = ex.Message,
+                Status = StatusCodes.Status409Conflict
+            });
+        }
+    }
+
+    [HttpGet("practice-sessions/{id:guid}/result", Name = RouteNames.GetPracticeSessionResult)]
+    public async Task<IActionResult> GetPracticeSessionResult([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        var practiceSession = await _practiceSessionService.GetByIdAsync(id, cancellationToken);
+        if (practiceSession is null)
+        {
+            return NotFound();
+        }
+
+        try
+        {
+            var result = await _practiceSessionService.GetResultAsync(id, cancellationToken);
+            if (result is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(ToResultResponse(practiceSession, result));
+        }
+        catch (PracticeSessionNotFinishedException ex)
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "Practice session not finished",
+                Detail = ex.Message,
+                Status = StatusCodes.Status409Conflict
+            });
+        }
+    }
+
+    private static PracticeSessionResponse ToResponse(PracticeSession practiceSession)
+    {
+        return new PracticeSessionResponse(
+            practiceSession.Id,
+            practiceSession.LessonId,
+            practiceSession.Status,
+            practiceSession.Exercises.Count,
+            practiceSession.CreatedAtUtc,
+            practiceSession.FinishedAtUtc);
+    }
+
+    private static PracticeSessionResultResponse ToResultResponse(
+        PracticeSession practiceSession,
+        PracticeSessionResult result)
+    {
+        return new PracticeSessionResultResponse(
+            result.PracticeSessionId,
+            practiceSession.Status,
+            result.TotalExercises,
+            result.AnsweredExercises,
+            result.CorrectAnswers,
+            result.ScorePercentage,
+            result.WeakPoints,
+            practiceSession.FinishedAtUtc);
+    }
+
+    private static class RouteNames
+    {
+        public const string GetPracticeSessionResult = nameof(GetPracticeSessionResult);
+    }
+}

--- a/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
+++ b/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
@@ -61,3 +61,34 @@ GET {{EnglishSeedEngine.Api_HostAddress}}/lessons/{{lessonId}}/materials
 Accept: application/json
 
 ###
+
+POST {{EnglishSeedEngine.Api_HostAddress}}/practice-sessions
+Content-Type: application/json
+
+{
+  "lessonId": "{{lessonId}}"
+}
+
+###
+
+POST {{EnglishSeedEngine.Api_HostAddress}}/practice-sessions/00000000-0000-0000-0000-000000000004/answers
+Content-Type: application/json
+
+{
+  "answers": [
+    { "exerciseIndex": 1, "answer": "review" },
+    { "exerciseIndex": 2, "answer": "This week I practice speaking." },
+    { "exerciseIndex": 3, "answer": "Speaking builds confidence every day." }
+  ]
+}
+
+###
+
+POST {{EnglishSeedEngine.Api_HostAddress}}/practice-sessions/00000000-0000-0000-0000-000000000004:finish
+
+###
+
+GET {{EnglishSeedEngine.Api_HostAddress}}/practice-sessions/00000000-0000-0000-0000-000000000004/result
+Accept: application/json
+
+###

--- a/src/EnglishSeedEngine.Api/Program.cs
+++ b/src/EnglishSeedEngine.Api/Program.cs
@@ -1,6 +1,7 @@
 using EnglishSeedEngine.Application.LearningPlans;
 using EnglishSeedEngine.Application.LessonMaterials;
 using EnglishSeedEngine.Application.Lessons;
+using EnglishSeedEngine.Application.PracticeSessions;
 using EnglishSeedEngine.Application.Students;
 using EnglishSeedEngine.Infrastructure;
 using EnglishSeedEngine.Infrastructure.Persistence;
@@ -16,6 +17,7 @@ builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<ILearningPlanService, LearningPlanService>();
 builder.Services.AddScoped<ILessonMaterialService, LessonMaterialService>();
 builder.Services.AddScoped<ILessonService, LessonService>();
+builder.Services.AddScoped<IPracticeSessionService, PracticeSessionService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddInfrastructure(builder.Configuration);
 

--- a/src/EnglishSeedEngine.Application/PracticeSessions/IPracticeSessionRepository.cs
+++ b/src/EnglishSeedEngine.Application/PracticeSessions/IPracticeSessionRepository.cs
@@ -1,0 +1,12 @@
+using EnglishSeedEngine.Domain.PracticeSessions;
+
+namespace EnglishSeedEngine.Application.PracticeSessions;
+
+public interface IPracticeSessionRepository
+{
+    Task AddAsync(PracticeSession practiceSession, CancellationToken cancellationToken);
+
+    Task<PracticeSession?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    Task UpdateAsync(PracticeSession practiceSession, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/PracticeSessions/IPracticeSessionService.cs
+++ b/src/EnglishSeedEngine.Application/PracticeSessions/IPracticeSessionService.cs
@@ -1,0 +1,19 @@
+using EnglishSeedEngine.Domain.PracticeSessions;
+
+namespace EnglishSeedEngine.Application.PracticeSessions;
+
+public interface IPracticeSessionService
+{
+    Task<PracticeSession?> GetByIdAsync(Guid practiceSessionId, CancellationToken cancellationToken);
+
+    Task<PracticeSession?> StartAsync(Guid lessonId, CancellationToken cancellationToken);
+
+    Task<PracticeSession?> SubmitAnswersAsync(
+        Guid practiceSessionId,
+        IReadOnlyCollection<PracticeSessionAnswer> answers,
+        CancellationToken cancellationToken);
+
+    Task<PracticeSession?> FinishAsync(Guid practiceSessionId, CancellationToken cancellationToken);
+
+    Task<PracticeSessionResult?> GetResultAsync(Guid practiceSessionId, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/PracticeSessions/LessonMaterialsRequiredException.cs
+++ b/src/EnglishSeedEngine.Application/PracticeSessions/LessonMaterialsRequiredException.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Application.PracticeSessions;
+
+public sealed class LessonMaterialsRequiredException : Exception
+{
+    public LessonMaterialsRequiredException(Guid lessonId)
+        : base($"Lesson {lessonId} requires generated materials before starting a practice session.")
+    {
+    }
+}

--- a/src/EnglishSeedEngine.Application/PracticeSessions/PracticeSessionFinishedException.cs
+++ b/src/EnglishSeedEngine.Application/PracticeSessions/PracticeSessionFinishedException.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Application.PracticeSessions;
+
+public sealed class PracticeSessionFinishedException : Exception
+{
+    public PracticeSessionFinishedException(Guid practiceSessionId)
+        : base($"Practice session {practiceSessionId} is already finished.")
+    {
+    }
+}

--- a/src/EnglishSeedEngine.Application/PracticeSessions/PracticeSessionNotFinishedException.cs
+++ b/src/EnglishSeedEngine.Application/PracticeSessions/PracticeSessionNotFinishedException.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Application.PracticeSessions;
+
+public sealed class PracticeSessionNotFinishedException : Exception
+{
+    public PracticeSessionNotFinishedException(Guid practiceSessionId)
+        : base($"Practice session {practiceSessionId} is not finished yet.")
+    {
+    }
+}

--- a/src/EnglishSeedEngine.Application/PracticeSessions/PracticeSessionService.cs
+++ b/src/EnglishSeedEngine.Application/PracticeSessions/PracticeSessionService.cs
@@ -1,0 +1,144 @@
+using EnglishSeedEngine.Application.LessonMaterials;
+using EnglishSeedEngine.Application.Lessons;
+using EnglishSeedEngine.Domain.PracticeSessions;
+using Microsoft.Extensions.Logging;
+
+namespace EnglishSeedEngine.Application.PracticeSessions;
+
+public sealed class PracticeSessionService : IPracticeSessionService
+{
+    private readonly ILessonRepository _lessonRepository;
+    private readonly ILessonMaterialRepository _lessonMaterialRepository;
+    private readonly IPracticeSessionRepository _practiceSessionRepository;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PracticeSessionService> _logger;
+
+    public PracticeSessionService(
+        ILessonRepository lessonRepository,
+        ILessonMaterialRepository lessonMaterialRepository,
+        IPracticeSessionRepository practiceSessionRepository,
+        TimeProvider timeProvider,
+        ILogger<PracticeSessionService> logger)
+    {
+        _lessonRepository = lessonRepository;
+        _lessonMaterialRepository = lessonMaterialRepository;
+        _practiceSessionRepository = practiceSessionRepository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public Task<PracticeSession?> GetByIdAsync(Guid practiceSessionId, CancellationToken cancellationToken)
+    {
+        return _practiceSessionRepository.GetByIdAsync(practiceSessionId, cancellationToken);
+    }
+
+    public async Task<PracticeSession?> StartAsync(Guid lessonId, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Practice session start requested for lesson {LessonId}", lessonId);
+
+        var lesson = await _lessonRepository.GetByIdAsync(lessonId, cancellationToken);
+        if (lesson is null)
+        {
+            _logger.LogWarning("Practice session start skipped because lesson {LessonId} was not found", lessonId);
+            return null;
+        }
+
+        var lessonMaterials = await _lessonMaterialRepository.GetByLessonIdAsync(lessonId, cancellationToken);
+        var latestMaterial = lessonMaterials
+            .OrderByDescending(x => x.Version)
+            .FirstOrDefault();
+
+        if (latestMaterial is null)
+        {
+            _logger.LogWarning("Practice session start blocked because lesson {LessonId} has no generated materials", lessonId);
+            throw new LessonMaterialsRequiredException(lessonId);
+        }
+
+        var practiceSession = PracticeSession.Start(
+            lessonId,
+            latestMaterial.Exercises,
+            _timeProvider.GetUtcNow().UtcDateTime);
+
+        await _practiceSessionRepository.AddAsync(practiceSession, cancellationToken);
+
+        _logger.LogInformation(
+            "Practice session {PracticeSessionId} started for lesson {LessonId}",
+            practiceSession.Id,
+            lessonId);
+
+        return practiceSession;
+    }
+
+    public async Task<PracticeSession?> SubmitAnswersAsync(
+        Guid practiceSessionId,
+        IReadOnlyCollection<PracticeSessionAnswer> answers,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Practice session answer submission started for session {PracticeSessionId}", practiceSessionId);
+
+        var practiceSession = await _practiceSessionRepository.GetByIdAsync(practiceSessionId, cancellationToken);
+        if (practiceSession is null)
+        {
+            _logger.LogWarning("Practice session answer submission skipped because session {PracticeSessionId} was not found", practiceSessionId);
+            return null;
+        }
+
+        try
+        {
+            practiceSession.SubmitAnswers(answers);
+            await _practiceSessionRepository.UpdateAsync(practiceSession, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Practice session answer submission failed because session {PracticeSessionId} is finished", practiceSessionId);
+            throw new PracticeSessionFinishedException(practiceSessionId);
+        }
+
+        _logger.LogInformation("Practice session answer submission completed for session {PracticeSessionId}", practiceSessionId);
+        return practiceSession;
+    }
+
+    public async Task<PracticeSession?> FinishAsync(Guid practiceSessionId, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Practice session finish started for session {PracticeSessionId}", practiceSessionId);
+
+        var practiceSession = await _practiceSessionRepository.GetByIdAsync(practiceSessionId, cancellationToken);
+        if (practiceSession is null)
+        {
+            _logger.LogWarning("Practice session finish skipped because session {PracticeSessionId} was not found", practiceSessionId);
+            return null;
+        }
+
+        try
+        {
+            practiceSession.Finish(_timeProvider.GetUtcNow().UtcDateTime);
+            await _practiceSessionRepository.UpdateAsync(practiceSession, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Practice session finish failed because session {PracticeSessionId} is already finished", practiceSessionId);
+            throw new PracticeSessionFinishedException(practiceSessionId);
+        }
+
+        _logger.LogInformation("Practice session finish completed for session {PracticeSessionId}", practiceSessionId);
+        return practiceSession;
+    }
+
+    public async Task<PracticeSessionResult?> GetResultAsync(Guid practiceSessionId, CancellationToken cancellationToken)
+    {
+        var practiceSession = await _practiceSessionRepository.GetByIdAsync(practiceSessionId, cancellationToken);
+        if (practiceSession is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return practiceSession.GetResult();
+        }
+        catch (InvalidOperationException)
+        {
+            throw new PracticeSessionNotFinishedException(practiceSessionId);
+        }
+    }
+}

--- a/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSession.cs
+++ b/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSession.cs
@@ -1,0 +1,256 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Domain.PracticeSessions;
+
+public sealed class PracticeSession
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private PracticeSession()
+    {
+    }
+
+    private PracticeSession(
+        Guid id,
+        Guid lessonId,
+        string status,
+        string exercisesJson,
+        int? scorePercentage,
+        string weakPointsJson,
+        DateTime createdAtUtc,
+        DateTime? finishedAtUtc)
+    {
+        Id = id;
+        LessonId = lessonId;
+        Status = status;
+        ExercisesJson = exercisesJson;
+        ScorePercentage = scorePercentage;
+        WeakPointsJson = weakPointsJson;
+        CreatedAtUtc = createdAtUtc;
+        FinishedAtUtc = finishedAtUtc;
+    }
+
+    public Guid Id { get; private set; }
+
+    public Guid LessonId { get; private set; }
+
+    public string Status { get; private set; } = string.Empty;
+
+    public string ExercisesJson { get; private set; } = "[]";
+
+    public int? ScorePercentage { get; private set; }
+
+    public string WeakPointsJson { get; private set; } = "[]";
+
+    public DateTime CreatedAtUtc { get; private set; }
+
+    public DateTime? FinishedAtUtc { get; private set; }
+
+    [NotMapped]
+    public IReadOnlyCollection<PracticeSessionExercise> Exercises => DeserializeExercises(ExercisesJson);
+
+    [NotMapped]
+    public IReadOnlyCollection<string> WeakPoints => DeserializeWeakPoints(WeakPointsJson);
+
+    [NotMapped]
+    public bool IsFinished => Status.Equals(Statuses.Finished, StringComparison.OrdinalIgnoreCase);
+
+    public static PracticeSession Start(
+        Guid lessonId,
+        IReadOnlyCollection<LessonMaterialExercise> exercises,
+        DateTime createdAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(exercises);
+
+        if (lessonId == Guid.Empty)
+        {
+            throw new ArgumentException("Lesson id is required.", nameof(lessonId));
+        }
+
+        if (exercises.Count == 0)
+        {
+            throw new ArgumentException("Exercises are required to start a session.", nameof(exercises));
+        }
+
+        var normalizedExercises = new List<PracticeSessionExercise>(exercises.Count);
+        var index = 1;
+
+        foreach (var exercise in exercises)
+        {
+            if (exercise is null)
+            {
+                throw new ArgumentException("Exercises cannot contain null elements.", nameof(exercises));
+            }
+
+            var type = exercise.Type.Trim().ToLowerInvariant();
+            var prompt = exercise.Prompt.Trim();
+            var expectedAnswer = exercise.ExpectedAnswer.Trim();
+
+            if (string.IsNullOrWhiteSpace(type))
+            {
+                throw new ArgumentException("Exercise type is required.", nameof(exercises));
+            }
+
+            if (string.IsNullOrWhiteSpace(prompt))
+            {
+                throw new ArgumentException("Exercise prompt is required.", nameof(exercises));
+            }
+
+            if (string.IsNullOrWhiteSpace(expectedAnswer))
+            {
+                throw new ArgumentException("Exercise expected answer is required.", nameof(exercises));
+            }
+
+            normalizedExercises.Add(new PracticeSessionExercise(index, type, prompt, expectedAnswer, SubmittedAnswer: null));
+            index++;
+        }
+
+        var normalizedCreatedAt = NormalizeUtc(createdAtUtc);
+
+        return new PracticeSession(
+            Guid.NewGuid(),
+            lessonId,
+            Statuses.InProgress,
+            JsonSerializer.Serialize(normalizedExercises, JsonSerializerOptions),
+            scorePercentage: null,
+            weakPointsJson: "[]",
+            normalizedCreatedAt,
+            finishedAtUtc: null);
+    }
+
+    public void SubmitAnswers(IReadOnlyCollection<PracticeSessionAnswer> answers)
+    {
+        ArgumentNullException.ThrowIfNull(answers);
+
+        EnsureInProgress();
+
+        var exercises = DeserializeExercises(ExercisesJson).ToList();
+        foreach (var answer in answers)
+        {
+            if (answer is null)
+            {
+                throw new ArgumentException("Answers cannot contain null elements.", nameof(answers));
+            }
+
+            var submittedAnswer = answer.Answer.Trim();
+            if (string.IsNullOrWhiteSpace(submittedAnswer))
+            {
+                throw new ArgumentException("Submitted answer cannot be empty.", nameof(answers));
+            }
+
+            var exerciseIndex = answer.ExerciseIndex;
+            var exercise = exercises.FirstOrDefault(x => x.ExerciseIndex == exerciseIndex);
+            if (exercise is null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(answers), $"Exercise index {exerciseIndex} does not exist.");
+            }
+
+            var updated = exercise with { SubmittedAnswer = submittedAnswer };
+            var currentPosition = exercises.FindIndex(x => x.ExerciseIndex == exerciseIndex);
+            exercises[currentPosition] = updated;
+        }
+
+        ExercisesJson = JsonSerializer.Serialize(exercises, JsonSerializerOptions);
+    }
+
+    public PracticeSessionResult Finish(DateTime finishedAtUtc)
+    {
+        EnsureInProgress();
+
+        var exercises = DeserializeExercises(ExercisesJson);
+        var correctAnswers = exercises.Count(IsCorrect);
+        var answeredExercises = exercises.Count(x => !string.IsNullOrWhiteSpace(x.SubmittedAnswer));
+        var totalExercises = exercises.Count;
+
+        var scorePercentage = totalExercises == 0
+            ? 0
+            : (int)Math.Round(correctAnswers * 100d / totalExercises, MidpointRounding.AwayFromZero);
+
+        var weakPoints = exercises
+            .Where(x => !IsCorrect(x))
+            .GroupBy(x => x.Type, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(x => x.Count())
+            .ThenBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(x => x.Key)
+            .ToArray();
+
+        Status = Statuses.Finished;
+        ScorePercentage = scorePercentage;
+        WeakPointsJson = JsonSerializer.Serialize(weakPoints, JsonSerializerOptions);
+        FinishedAtUtc = NormalizeUtc(finishedAtUtc);
+
+        return new PracticeSessionResult(
+            Id,
+            totalExercises,
+            answeredExercises,
+            correctAnswers,
+            scorePercentage,
+            weakPoints);
+    }
+
+    public PracticeSessionResult GetResult()
+    {
+        if (!IsFinished || ScorePercentage is null)
+        {
+            throw new InvalidOperationException("Practice session is not finished yet.");
+        }
+
+        var exercises = DeserializeExercises(ExercisesJson);
+        return new PracticeSessionResult(
+            Id,
+            exercises.Count,
+            exercises.Count(x => !string.IsNullOrWhiteSpace(x.SubmittedAnswer)),
+            exercises.Count(IsCorrect),
+            ScorePercentage.Value,
+            DeserializeWeakPoints(WeakPointsJson));
+    }
+
+    private static bool IsCorrect(PracticeSessionExercise exercise)
+    {
+        if (string.IsNullOrWhiteSpace(exercise.SubmittedAnswer))
+        {
+            return false;
+        }
+
+        return string.Equals(
+            exercise.SubmittedAnswer.Trim(),
+            exercise.ExpectedAnswer.Trim(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void EnsureInProgress()
+    {
+        if (!Status.Equals(Statuses.InProgress, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Practice session is already finished.");
+        }
+    }
+
+    private static IReadOnlyCollection<PracticeSessionExercise> DeserializeExercises(string json)
+    {
+        return JsonSerializer.Deserialize<PracticeSessionExercise[]>(json, JsonSerializerOptions) ?? [];
+    }
+
+    private static IReadOnlyCollection<string> DeserializeWeakPoints(string json)
+    {
+        return JsonSerializer.Deserialize<string[]>(json, JsonSerializerOptions) ?? [];
+    }
+
+    private static DateTime NormalizeUtc(DateTime value)
+    {
+        var utcValue = value.Kind == DateTimeKind.Utc
+            ? value
+            : value.ToUniversalTime();
+
+        var truncatedTicks = utcValue.Ticks - (utcValue.Ticks % TimeSpan.TicksPerMicrosecond);
+        return new DateTime(truncatedTicks, DateTimeKind.Utc);
+    }
+
+    public static class Statuses
+    {
+        public const string InProgress = "InProgress";
+        public const string Finished = "Finished";
+    }
+}

--- a/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSessionAnswer.cs
+++ b/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSessionAnswer.cs
@@ -1,0 +1,5 @@
+namespace EnglishSeedEngine.Domain.PracticeSessions;
+
+public sealed record PracticeSessionAnswer(
+    int ExerciseIndex,
+    string Answer);

--- a/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSessionExercise.cs
+++ b/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSessionExercise.cs
@@ -1,0 +1,8 @@
+namespace EnglishSeedEngine.Domain.PracticeSessions;
+
+public sealed record PracticeSessionExercise(
+    int ExerciseIndex,
+    string Type,
+    string Prompt,
+    string ExpectedAnswer,
+    string? SubmittedAnswer);

--- a/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSessionResult.cs
+++ b/src/EnglishSeedEngine.Domain/PracticeSessions/PracticeSessionResult.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Domain.PracticeSessions;
+
+public sealed record PracticeSessionResult(
+    Guid PracticeSessionId,
+    int TotalExercises,
+    int AnsweredExercises,
+    int CorrectAnswers,
+    int ScorePercentage,
+    IReadOnlyCollection<string> WeakPoints);

--- a/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
+++ b/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using EnglishSeedEngine.Application.LearningPlans;
 using EnglishSeedEngine.Application.LessonMaterials;
 using EnglishSeedEngine.Application.Lessons;
+using EnglishSeedEngine.Application.PracticeSessions;
 using EnglishSeedEngine.Application.Students;
 using EnglishSeedEngine.Infrastructure.LessonMaterials;
 using EnglishSeedEngine.Infrastructure.Persistence;
@@ -28,6 +29,7 @@ public static class DependencyInjection
         services.AddScoped<ILessonRepository, LessonRepository>();
         services.AddScoped<ILessonMaterialRepository, LessonMaterialRepository>();
         services.AddScoped<ILessonMaterialGenerator, TemplateLessonMaterialGenerator>();
+        services.AddScoped<IPracticeSessionRepository, PracticeSessionRepository>();
 
         return services;
     }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
@@ -1,5 +1,6 @@
 using EnglishSeedEngine.Domain.LearningPlans;
 using EnglishSeedEngine.Domain.Lessons;
+using EnglishSeedEngine.Domain.PracticeSessions;
 using EnglishSeedEngine.Domain.Students;
 using Microsoft.EntityFrameworkCore;
 
@@ -19,6 +20,8 @@ public sealed class AppDbContext : DbContext
     public DbSet<Lesson> Lessons => Set<Lesson>();
 
     public DbSet<LessonMaterial> LessonMaterials => Set<LessonMaterial>();
+
+    public DbSet<PracticeSession> PracticeSessions => Set<PracticeSession>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -76,5 +79,17 @@ public sealed class AppDbContext : DbContext
         lessonMaterial.Property(x => x.GeneratedAtUtc).IsRequired();
         lessonMaterial.HasIndex(x => x.LessonId);
         lessonMaterial.HasIndex(x => new { x.LessonId, x.Version }).IsUnique();
+
+        var practiceSession = modelBuilder.Entity<PracticeSession>();
+        practiceSession.ToTable("practice_sessions");
+        practiceSession.HasKey(x => x.Id);
+        practiceSession.Property(x => x.LessonId).IsRequired();
+        practiceSession.Property(x => x.Status).HasMaxLength(24).IsRequired();
+        practiceSession.Property(x => x.ExercisesJson).HasColumnType("jsonb").IsRequired();
+        practiceSession.Property(x => x.ScorePercentage);
+        practiceSession.Property(x => x.WeakPointsJson).HasColumnType("jsonb").IsRequired();
+        practiceSession.Property(x => x.CreatedAtUtc).IsRequired();
+        practiceSession.Property(x => x.FinishedAtUtc);
+        practiceSession.HasIndex(x => x.LessonId);
     }
 }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/PracticeSessionRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/PracticeSessionRepository.cs
@@ -1,0 +1,38 @@
+using EnglishSeedEngine.Application.PracticeSessions;
+using EnglishSeedEngine.Domain.PracticeSessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnglishSeedEngine.Infrastructure.Persistence.Repositories;
+
+public sealed class PracticeSessionRepository : IPracticeSessionRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public PracticeSessionRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(PracticeSession practiceSession, CancellationToken cancellationToken)
+    {
+        await _dbContext.PracticeSessions.AddAsync(practiceSession, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<PracticeSession?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.PracticeSessions
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+
+    public async Task UpdateAsync(PracticeSession practiceSession, CancellationToken cancellationToken)
+    {
+        if (_dbContext.Entry(practiceSession).State == EntityState.Detached)
+        {
+            _dbContext.PracticeSessions.Attach(practiceSession);
+            _dbContext.Entry(practiceSession).State = EntityState.Modified;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/PracticeSessions/PracticeSessionsEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/PracticeSessions/PracticeSessionsEndpointsTests.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using System.Net.Http.Json;
+using EnglishSeedEngine.Api.Contracts.LearningPlans;
+using EnglishSeedEngine.Api.Contracts.Lessons;
+using EnglishSeedEngine.Api.Contracts.PracticeSessions;
+using EnglishSeedEngine.Api.Contracts.Students;
+using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.IntegrationTests.PracticeSessions;
+
+[Collection(ApiTestCollection.Name)]
+public sealed class PracticeSessionsEndpointsTests : ApiTestBase
+{
+    public PracticeSessionsEndpointsTests(ApiIntegrationTestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task StartSession_Returns201()
+    {
+        var setup = await CreateLessonWithMaterialsAsync();
+
+        var startResponse = await Client.PostAsJsonAsync(
+            "/practice-sessions",
+            new CreatePracticeSessionRequest { LessonId = setup.Lesson.Id });
+
+        startResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        startResponse.Headers.Location.Should().NotBeNull();
+
+        var session = await startResponse.Content.ReadFromJsonAsync<PracticeSessionResponse>();
+        session.Should().NotBeNull();
+        session!.LessonId.Should().Be(setup.Lesson.Id);
+        session.Status.Should().Be("InProgress");
+        session.TotalExercises.Should().Be(3);
+        session.FinishedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StartSession_LessonNotFound_Returns404()
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/practice-sessions",
+            new CreatePracticeSessionRequest { LessonId = Guid.NewGuid() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_AfterFinish_Returns409()
+    {
+        var setup = await CreateLessonWithMaterialsAsync();
+        var session = await StartPracticeSessionAsync(setup.Lesson.Id);
+
+        var firstSubmitResponse = await SubmitAnswersAsync(session.Id, setup.Material, wrongExerciseType: null);
+        firstSubmitResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var finishResponse = await Client.PostAsync($"/practice-sessions/{session.Id}:finish", content: null);
+        finishResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var submitAfterFinishResponse = await SubmitAnswersAsync(session.Id, setup.Material, wrongExerciseType: null);
+        submitAfterFinishResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task FinishSession_ComputesScoreAndWeakPoints()
+    {
+        var setup = await CreateLessonWithMaterialsAsync();
+        var session = await StartPracticeSessionAsync(setup.Lesson.Id);
+
+        var submitResponse = await SubmitAnswersAsync(session.Id, setup.Material, wrongExerciseType: "translation");
+        submitResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var finishResponse = await Client.PostAsync($"/practice-sessions/{session.Id}:finish", content: null);
+        finishResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await finishResponse.Content.ReadFromJsonAsync<PracticeSessionResultResponse>();
+        result.Should().NotBeNull();
+        result!.PracticeSessionId.Should().Be(session.Id);
+        result.Status.Should().Be("Finished");
+        result.ScorePercentage.Should().Be(67);
+        result.CorrectAnswers.Should().Be(2);
+        result.TotalExercises.Should().Be(3);
+        result.WeakPoints.Should().Contain("translation");
+
+        var getResultResponse = await Client.GetAsync($"/practice-sessions/{session.Id}/result");
+        getResultResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var persistedResult = await getResultResponse.Content.ReadFromJsonAsync<PracticeSessionResultResponse>();
+        persistedResult.Should().NotBeNull();
+        persistedResult!.ScorePercentage.Should().Be(result.ScorePercentage);
+        persistedResult.WeakPoints.Should().BeEquivalentTo(result.WeakPoints);
+    }
+
+    private async Task<HttpResponseMessage> SubmitAnswersAsync(
+        Guid sessionId,
+        LessonMaterialResponse material,
+        string? wrongExerciseType)
+    {
+        var answers = material.Exercises
+            .Select((exercise, index) => new SubmitPracticeSessionAnswerRequest
+            {
+                ExerciseIndex = index + 1,
+                Answer = wrongExerciseType is not null &&
+                         exercise.Type.Equals(wrongExerciseType, StringComparison.OrdinalIgnoreCase)
+                    ? "wrong answer"
+                    : exercise.ExpectedAnswer
+            })
+            .ToArray();
+
+        return await Client.PostAsJsonAsync(
+            $"/practice-sessions/{sessionId}/answers",
+            new SubmitPracticeSessionAnswersRequest { Answers = answers });
+    }
+
+    private async Task<PracticeSessionResponse> StartPracticeSessionAsync(Guid lessonId)
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/practice-sessions",
+            new CreatePracticeSessionRequest { LessonId = lessonId });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var practiceSession = await response.Content.ReadFromJsonAsync<PracticeSessionResponse>();
+        practiceSession.Should().NotBeNull();
+
+        return practiceSession!;
+    }
+
+    private async Task<(LessonResponse Lesson, LessonMaterialResponse Material)> CreateLessonWithMaterialsAsync()
+    {
+        var lesson = await CreateLessonAsync();
+
+        var generateMaterialsResponse = await Client.PostAsync($"/lessons/{lesson.Id}/materials:generate", content: null);
+        generateMaterialsResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var material = await generateMaterialsResponse.Content.ReadFromJsonAsync<LessonMaterialResponse>();
+        material.Should().NotBeNull();
+
+        return (lesson, material!);
+    }
+
+    private async Task<LessonResponse> CreateLessonAsync()
+    {
+        var plan = await CreateLearningPlanAsync();
+
+        var response = await Client.PostAsync($"/learning-plans/{plan.Id}/lessons:next", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var lesson = await response.Content.ReadFromJsonAsync<LessonResponse>();
+        lesson.Should().NotBeNull();
+
+        return lesson!;
+    }
+
+    private async Task<LearningPlanResponse> CreateLearningPlanAsync()
+    {
+        var student = await CreateStudentAsync();
+        await SubmitInitialAssessmentAsync(student.Id, correctAnswers: 8, totalQuestions: 10);
+
+        var response = await Client.PostAsync($"/students/{student.Id}/learning-plans", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var plan = await response.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        plan.Should().NotBeNull();
+
+        return plan!;
+    }
+
+    private async Task<StudentResponse> CreateStudentAsync()
+    {
+        var request = new CreateStudentRequest
+        {
+            FullName = "Practice Student",
+            Age = 12,
+            TutorEmail = $"parent.practice.{Guid.NewGuid():N}@example.com",
+            TargetLevel = "B1"
+        };
+
+        var response = await Client.PostAsJsonAsync("/students", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var student = await response.Content.ReadFromJsonAsync<StudentResponse>();
+        student.Should().NotBeNull();
+
+        return student!;
+    }
+
+    private async Task SubmitInitialAssessmentAsync(Guid studentId, int correctAnswers, int totalQuestions)
+    {
+        var response = await Client.PostAsJsonAsync(
+            $"/students/{studentId}/assessments/initial",
+            new SubmitInitialAssessmentRequest
+            {
+                CorrectAnswers = correctAnswers,
+                TotalQuestions = totalQuestions
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}

--- a/tests/EnglishSeedEngine.UnitTests/PracticeSessions/PracticeSessionTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/PracticeSessions/PracticeSessionTests.cs
@@ -1,0 +1,68 @@
+using EnglishSeedEngine.Domain.Lessons;
+using EnglishSeedEngine.Domain.PracticeSessions;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.UnitTests.PracticeSessions;
+
+public sealed class PracticeSessionTests
+{
+    [Fact]
+    public void Finish_WithSubmittedAnswers_ComputesScoreAndWeakPoints()
+    {
+        var practiceSession = PracticeSession.Start(
+            Guid.NewGuid(),
+            BuildLessonExercises(),
+            DateTime.UtcNow);
+
+        practiceSession.SubmitAnswers(
+        [
+            new PracticeSessionAnswer(1, "review"),
+            new PracticeSessionAnswer(2, "incorrect answer"),
+            new PracticeSessionAnswer(3, "Daily routine builds confidence.")
+        ]);
+
+        var result = practiceSession.Finish(DateTime.UtcNow);
+
+        result.TotalExercises.Should().Be(3);
+        result.CorrectAnswers.Should().Be(2);
+        result.ScorePercentage.Should().Be(67);
+        result.WeakPoints.Should().ContainSingle().Which.Should().Be("translation");
+        practiceSession.Status.Should().Be(PracticeSession.Statuses.Finished);
+    }
+
+    [Fact]
+    public void SubmitAnswers_AfterFinish_ThrowsInvalidOperationException()
+    {
+        var practiceSession = PracticeSession.Start(
+            Guid.NewGuid(),
+            BuildLessonExercises(),
+            DateTime.UtcNow);
+
+        practiceSession.Finish(DateTime.UtcNow);
+
+        var action = () => practiceSession.SubmitAnswers(
+        [
+            new PracticeSessionAnswer(1, "review")
+        ]);
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Start_WithoutExercises_ThrowsArgumentException()
+    {
+        var action = () => PracticeSession.Start(Guid.NewGuid(), [], DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    private static LessonMaterialExercise[] BuildLessonExercises()
+    {
+        return
+        [
+            new LessonMaterialExercise("cloze", "Complete the sentence", "review"),
+            new LessonMaterialExercise("translation", "Translate sentence", "I practice every day."),
+            new LessonMaterialExercise("dictation", "Write exactly", "Daily routine builds confidence.")
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add practice session domain model and persistence for session lifecycle and answer tracking
- expose practice session endpoints for start, answer submission, finish, and result retrieval
- compute score percentage and weak points from submitted answers
- block answer submission after finish with controlled 409 response
- add unit and integration coverage for required scenarios

## Testing
- dotnet test --no-restore

Closes #9