### PR TITLE
feat: tune next lesson difficulty from parent feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 - Next lesson generation and lesson retrieval endpoints.
 - Lesson materials generation (versioned) and retrieval endpoints.
 - Practice session lifecycle with scoring and weak points endpoints.
+- Parent feedback endpoint to tune next lesson difficulty.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 

--- a/src/EnglishSeedEngine.Api/Contracts/Lessons/ParentFeedbackResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Lessons/ParentFeedbackResponse.cs
@@ -1,0 +1,8 @@
+namespace EnglishSeedEngine.Api.Contracts.Lessons;
+
+public sealed record ParentFeedbackResponse(
+    Guid Id,
+    Guid LessonId,
+    string Rating,
+    int DifficultyDelta,
+    DateTime SubmittedAtUtc);

--- a/src/EnglishSeedEngine.Api/Contracts/Lessons/SubmitParentFeedbackRequest.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Lessons/SubmitParentFeedbackRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EnglishSeedEngine.Api.Contracts.Lessons;
+
+public sealed class SubmitParentFeedbackRequest
+{
+    [Required]
+    [RegularExpression("^(too_easy|adequate|too_hard)$")]
+    public string Rating { get; init; } = string.Empty;
+}

--- a/src/EnglishSeedEngine.Api/Controllers/LessonsController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/LessonsController.cs
@@ -10,13 +10,16 @@ public sealed class LessonsController : ControllerBase
 {
     private readonly ILessonService _lessonService;
     private readonly ILessonMaterialService _lessonMaterialService;
+    private readonly IParentFeedbackService _parentFeedbackService;
 
     public LessonsController(
         ILessonService lessonService,
-        ILessonMaterialService lessonMaterialService)
+        ILessonMaterialService lessonMaterialService,
+        IParentFeedbackService parentFeedbackService)
     {
         _lessonService = lessonService;
         _lessonMaterialService = lessonMaterialService;
+        _parentFeedbackService = parentFeedbackService;
     }
 
     [HttpGet("lessons/{id:guid}", Name = RouteNames.GetLessonById)]
@@ -78,6 +81,37 @@ public sealed class LessonsController : ControllerBase
         return Ok(response);
     }
 
+    [HttpPost("lessons/{id:guid}/parent-feedback")]
+    public async Task<IActionResult> SubmitParentFeedback(
+        [FromRoute] Guid id,
+        [FromBody] SubmitParentFeedbackRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var parentFeedback = await _parentFeedbackService.SubmitAsync(id, request.Rating, cancellationToken);
+
+            if (parentFeedback is null)
+            {
+                return NotFound();
+            }
+
+            return CreatedAtRoute(
+                RouteNames.GetLessonById,
+                new { id },
+                ToParentFeedbackResponse(parentFeedback));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid parent feedback",
+                Detail = ex.Message,
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+    }
+
     internal static LessonResponse ToResponse(Domain.Lessons.Lesson lesson)
     {
         return new LessonResponse(
@@ -102,6 +136,16 @@ public sealed class LessonsController : ControllerBase
             lessonMaterial.Exercises
                 .Select(x => new LessonMaterialExerciseResponse(x.Type, x.Prompt, x.ExpectedAnswer))
                 .ToArray());
+    }
+
+    internal static ParentFeedbackResponse ToParentFeedbackResponse(Domain.Lessons.ParentFeedback parentFeedback)
+    {
+        return new ParentFeedbackResponse(
+            parentFeedback.Id,
+            parentFeedback.LessonId,
+            parentFeedback.Rating,
+            parentFeedback.DifficultyDelta,
+            parentFeedback.SubmittedAtUtc);
     }
 
     internal static class RouteNames

--- a/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
+++ b/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
@@ -53,6 +53,15 @@ Accept: application/json
 
 ###
 
+POST {{EnglishSeedEngine.Api_HostAddress}}/lessons/{{lessonId}}/parent-feedback
+Content-Type: application/json
+
+{
+  "rating": "adequate"
+}
+
+###
+
 POST {{EnglishSeedEngine.Api_HostAddress}}/lessons/{{lessonId}}/materials:generate
 
 ###

--- a/src/EnglishSeedEngine.Api/Program.cs
+++ b/src/EnglishSeedEngine.Api/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddHealthChecks();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<ILearningPlanService, LearningPlanService>();
 builder.Services.AddScoped<ILessonMaterialService, LessonMaterialService>();
+builder.Services.AddScoped<IParentFeedbackService, ParentFeedbackService>();
 builder.Services.AddScoped<ILessonService, LessonService>();
 builder.Services.AddScoped<IPracticeSessionService, PracticeSessionService>();
 builder.Services.AddScoped<IStudentService, StudentService>();

--- a/src/EnglishSeedEngine.Application/Lessons/ILessonRepository.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/ILessonRepository.cs
@@ -9,4 +9,6 @@ public interface ILessonRepository
     Task<Lesson?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 
     Task<int> CountByLearningPlanIdAsync(Guid learningPlanId, CancellationToken cancellationToken);
+
+    Task<Lesson?> GetLatestByLearningPlanIdAsync(Guid learningPlanId, CancellationToken cancellationToken);
 }

--- a/src/EnglishSeedEngine.Application/Lessons/IParentFeedbackRepository.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/IParentFeedbackRepository.cs
@@ -1,0 +1,10 @@
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.Lessons;
+
+public interface IParentFeedbackRepository
+{
+    Task AddAsync(ParentFeedback parentFeedback, CancellationToken cancellationToken);
+
+    Task<ParentFeedback?> GetLatestByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/Lessons/IParentFeedbackService.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/IParentFeedbackService.cs
@@ -1,0 +1,8 @@
+using EnglishSeedEngine.Domain.Lessons;
+
+namespace EnglishSeedEngine.Application.Lessons;
+
+public interface IParentFeedbackService
+{
+    Task<ParentFeedback?> SubmitAsync(Guid lessonId, string rating, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/Lessons/LessonService.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/LessonService.cs
@@ -6,15 +6,18 @@ namespace EnglishSeedEngine.Application.Lessons;
 public sealed class LessonService : ILessonService
 {
     private readonly ILessonRepository _lessonRepository;
+    private readonly IParentFeedbackRepository _parentFeedbackRepository;
     private readonly ILearningPlanRepository _learningPlanRepository;
     private readonly TimeProvider _timeProvider;
 
     public LessonService(
         ILessonRepository lessonRepository,
+        IParentFeedbackRepository parentFeedbackRepository,
         ILearningPlanRepository learningPlanRepository,
         TimeProvider timeProvider)
     {
         _lessonRepository = lessonRepository;
+        _parentFeedbackRepository = parentFeedbackRepository;
         _learningPlanRepository = learningPlanRepository;
         _timeProvider = timeProvider;
     }
@@ -33,12 +36,17 @@ public sealed class LessonService : ILessonService
         try
         {
             var draft = learningPlan.GetNextLessonDraft(existingLessons);
+            var adjustedDifficulty = await ResolveAdjustedDifficultyAsync(
+                learningPlan.Id,
+                existingLessons,
+                draft.TargetDifficulty,
+                cancellationToken);
 
             var lesson = Lesson.Create(
                 learningPlan.Id,
                 draft.WeekNumber,
                 draft.WeeklyFocus,
-                draft.TargetDifficulty,
+                adjustedDifficulty,
                 _timeProvider.GetUtcNow().UtcDateTime);
 
             await _lessonRepository.AddAsync(lesson, cancellationToken);
@@ -61,5 +69,52 @@ public sealed class LessonService : ILessonService
     public Task<Lesson?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
     {
         return _lessonRepository.GetByIdAsync(id, cancellationToken);
+    }
+
+    private async Task<string> ResolveAdjustedDifficultyAsync(
+        Guid learningPlanId,
+        int existingLessons,
+        string baseDifficulty,
+        CancellationToken cancellationToken)
+    {
+        if (existingLessons == 0)
+        {
+            return baseDifficulty;
+        }
+
+        var latestLesson = await _lessonRepository.GetLatestByLearningPlanIdAsync(learningPlanId, cancellationToken);
+        if (latestLesson is null)
+        {
+            return baseDifficulty;
+        }
+
+        var latestFeedback = await _parentFeedbackRepository.GetLatestByLessonIdAsync(latestLesson.Id, cancellationToken);
+        if (latestFeedback is null)
+        {
+            return baseDifficulty;
+        }
+
+        return AdjustDifficulty(baseDifficulty, latestFeedback.DifficultyDelta);
+    }
+
+    private static string AdjustDifficulty(string baseDifficulty, int difficultyDelta)
+    {
+        var baseLevel = baseDifficulty switch
+        {
+            "Easy" => 1,
+            "Medium" => 2,
+            "Hard" => 3,
+            _ => 2
+        };
+
+        var adjustedLevel = Math.Clamp(baseLevel + difficultyDelta, 1, 3);
+
+        return adjustedLevel switch
+        {
+            1 => "Easy",
+            2 => "Medium",
+            3 => "Hard",
+            _ => "Medium"
+        };
     }
 }

--- a/src/EnglishSeedEngine.Application/Lessons/ParentFeedbackService.cs
+++ b/src/EnglishSeedEngine.Application/Lessons/ParentFeedbackService.cs
@@ -1,0 +1,50 @@
+using EnglishSeedEngine.Domain.Lessons;
+using Microsoft.Extensions.Logging;
+
+namespace EnglishSeedEngine.Application.Lessons;
+
+public sealed class ParentFeedbackService : IParentFeedbackService
+{
+    private readonly ILessonRepository _lessonRepository;
+    private readonly IParentFeedbackRepository _parentFeedbackRepository;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ParentFeedbackService> _logger;
+
+    public ParentFeedbackService(
+        ILessonRepository lessonRepository,
+        IParentFeedbackRepository parentFeedbackRepository,
+        TimeProvider timeProvider,
+        ILogger<ParentFeedbackService> logger)
+    {
+        _lessonRepository = lessonRepository;
+        _parentFeedbackRepository = parentFeedbackRepository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<ParentFeedback?> SubmitAsync(Guid lessonId, string rating, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Parent feedback submission started for lesson {LessonId}", lessonId);
+
+        var lesson = await _lessonRepository.GetByIdAsync(lessonId, cancellationToken);
+        if (lesson is null)
+        {
+            _logger.LogWarning("Parent feedback submission skipped because lesson {LessonId} was not found", lessonId);
+            return null;
+        }
+
+        var parentFeedback = ParentFeedback.Create(
+            lessonId,
+            rating,
+            _timeProvider.GetUtcNow().UtcDateTime);
+
+        await _parentFeedbackRepository.AddAsync(parentFeedback, cancellationToken);
+
+        _logger.LogInformation(
+            "Parent feedback submission completed for lesson {LessonId} with rating {Rating}",
+            lessonId,
+            parentFeedback.Rating);
+
+        return parentFeedback;
+    }
+}

--- a/src/EnglishSeedEngine.Domain/Lessons/ParentFeedback.cs
+++ b/src/EnglishSeedEngine.Domain/Lessons/ParentFeedback.cs
@@ -1,0 +1,82 @@
+namespace EnglishSeedEngine.Domain.Lessons;
+
+public sealed class ParentFeedback
+{
+    private ParentFeedback()
+    {
+    }
+
+    private ParentFeedback(
+        Guid id,
+        Guid lessonId,
+        string rating,
+        int difficultyDelta,
+        DateTime submittedAtUtc)
+    {
+        Id = id;
+        LessonId = lessonId;
+        Rating = rating;
+        DifficultyDelta = difficultyDelta;
+        SubmittedAtUtc = submittedAtUtc;
+    }
+
+    public Guid Id { get; private set; }
+
+    public Guid LessonId { get; private set; }
+
+    public string Rating { get; private set; } = string.Empty;
+
+    public int DifficultyDelta { get; private set; }
+
+    public DateTime SubmittedAtUtc { get; private set; }
+
+    public static ParentFeedback Create(Guid lessonId, string rating, DateTime submittedAtUtc)
+    {
+        if (lessonId == Guid.Empty)
+        {
+            throw new ArgumentException("Lesson id is required.", nameof(lessonId));
+        }
+
+        if (string.IsNullOrWhiteSpace(rating))
+        {
+            throw new ArgumentException("Rating is required.", nameof(rating));
+        }
+
+        var normalizedRating = rating.Trim().ToLowerInvariant();
+        var delta = normalizedRating switch
+        {
+            Ratings.TooEasy => 1,
+            Ratings.Adequate => 0,
+            Ratings.TooHard => -1,
+            _ => throw new ArgumentException(
+                $"Rating must be one of: {Ratings.TooEasy}, {Ratings.Adequate}, {Ratings.TooHard}.",
+                nameof(rating))
+        };
+
+        var normalizedSubmittedAt = NormalizeUtc(submittedAtUtc);
+
+        return new ParentFeedback(
+            Guid.NewGuid(),
+            lessonId,
+            normalizedRating,
+            delta,
+            normalizedSubmittedAt);
+    }
+
+    private static DateTime NormalizeUtc(DateTime value)
+    {
+        var utcValue = value.Kind == DateTimeKind.Utc
+            ? value
+            : value.ToUniversalTime();
+
+        var truncatedTicks = utcValue.Ticks - (utcValue.Ticks % TimeSpan.TicksPerMicrosecond);
+        return new DateTime(truncatedTicks, DateTimeKind.Utc);
+    }
+
+    public static class Ratings
+    {
+        public const string TooEasy = "too_easy";
+        public const string Adequate = "adequate";
+        public const string TooHard = "too_hard";
+    }
+}

--- a/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
+++ b/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
@@ -27,6 +27,7 @@ public static class DependencyInjection
         services.AddScoped<IStudentRepository, StudentRepository>();
         services.AddScoped<ILearningPlanRepository, LearningPlanRepository>();
         services.AddScoped<ILessonRepository, LessonRepository>();
+        services.AddScoped<IParentFeedbackRepository, ParentFeedbackRepository>();
         services.AddScoped<ILessonMaterialRepository, LessonMaterialRepository>();
         services.AddScoped<ILessonMaterialGenerator, TemplateLessonMaterialGenerator>();
         services.AddScoped<IPracticeSessionRepository, PracticeSessionRepository>();

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/AppDbContext.cs
@@ -21,6 +21,8 @@ public sealed class AppDbContext : DbContext
 
     public DbSet<LessonMaterial> LessonMaterials => Set<LessonMaterial>();
 
+    public DbSet<ParentFeedback> ParentFeedbacks => Set<ParentFeedback>();
+
     public DbSet<PracticeSession> PracticeSessions => Set<PracticeSession>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -79,6 +81,15 @@ public sealed class AppDbContext : DbContext
         lessonMaterial.Property(x => x.GeneratedAtUtc).IsRequired();
         lessonMaterial.HasIndex(x => x.LessonId);
         lessonMaterial.HasIndex(x => new { x.LessonId, x.Version }).IsUnique();
+
+        var parentFeedback = modelBuilder.Entity<ParentFeedback>();
+        parentFeedback.ToTable("parent_feedbacks");
+        parentFeedback.HasKey(x => x.Id);
+        parentFeedback.Property(x => x.LessonId).IsRequired();
+        parentFeedback.Property(x => x.Rating).HasMaxLength(24).IsRequired();
+        parentFeedback.Property(x => x.DifficultyDelta).IsRequired();
+        parentFeedback.Property(x => x.SubmittedAtUtc).IsRequired();
+        parentFeedback.HasIndex(x => x.LessonId);
 
         var practiceSession = modelBuilder.Entity<PracticeSession>();
         practiceSession.ToTable("practice_sessions");

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LessonRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/LessonRepository.cs
@@ -32,4 +32,14 @@ public sealed class LessonRepository : ILessonRepository
             .AsNoTracking()
             .CountAsync(x => x.LearningPlanId == learningPlanId, cancellationToken);
     }
+
+    public Task<Lesson?> GetLatestByLearningPlanIdAsync(Guid learningPlanId, CancellationToken cancellationToken)
+    {
+        return _dbContext.Lessons
+            .AsNoTracking()
+            .Where(x => x.LearningPlanId == learningPlanId)
+            .OrderByDescending(x => x.WeekNumber)
+            .ThenByDescending(x => x.CreatedAtUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
 }

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/ParentFeedbackRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/ParentFeedbackRepository.cs
@@ -1,0 +1,30 @@
+using EnglishSeedEngine.Application.Lessons;
+using EnglishSeedEngine.Domain.Lessons;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnglishSeedEngine.Infrastructure.Persistence.Repositories;
+
+public sealed class ParentFeedbackRepository : IParentFeedbackRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public ParentFeedbackRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(ParentFeedback parentFeedback, CancellationToken cancellationToken)
+    {
+        await _dbContext.ParentFeedbacks.AddAsync(parentFeedback, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<ParentFeedback?> GetLatestByLessonIdAsync(Guid lessonId, CancellationToken cancellationToken)
+    {
+        return _dbContext.ParentFeedbacks
+            .AsNoTracking()
+            .Where(x => x.LessonId == lessonId)
+            .OrderByDescending(x => x.SubmittedAtUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/Lessons/ParentFeedbackEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Lessons/ParentFeedbackEndpointsTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using System.Net.Http.Json;
+using EnglishSeedEngine.Api.Contracts.LearningPlans;
+using EnglishSeedEngine.Api.Contracts.Lessons;
+using EnglishSeedEngine.Api.Contracts.Students;
+using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.IntegrationTests.Lessons;
+
+[Collection(ApiTestCollection.Name)]
+public sealed class ParentFeedbackEndpointsTests : ApiTestBase
+{
+    public ParentFeedbackEndpointsTests(ApiIntegrationTestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task SubmitFeedback_AdjustsNextLessonDifficulty()
+    {
+        var plan = await CreateLearningPlanAsync();
+        var firstLesson = await CreateNextLessonAsync(plan.Id);
+        firstLesson.TargetDifficulty.Should().Be("Easy");
+
+        var submitFeedbackResponse = await Client.PostAsJsonAsync(
+            $"/lessons/{firstLesson.Id}/parent-feedback",
+            new SubmitParentFeedbackRequest { Rating = "too_easy" });
+
+        submitFeedbackResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var secondLesson = await CreateNextLessonAsync(plan.Id);
+        secondLesson.TargetDifficulty.Should().Be("Hard");
+    }
+
+    [Fact]
+    public async Task SubmitFeedback_InvalidValue_Returns400()
+    {
+        var plan = await CreateLearningPlanAsync();
+        var lesson = await CreateNextLessonAsync(plan.Id);
+
+        var response = await Client.PostAsJsonAsync(
+            $"/lessons/{lesson.Id}/parent-feedback",
+            new SubmitParentFeedbackRequest { Rating = "invalid" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SubmitFeedback_LessonNotFound_Returns404()
+    {
+        var response = await Client.PostAsJsonAsync(
+            $"/lessons/{Guid.NewGuid()}/parent-feedback",
+            new SubmitParentFeedbackRequest { Rating = "adequate" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task<LessonResponse> CreateNextLessonAsync(Guid learningPlanId)
+    {
+        var response = await Client.PostAsync($"/learning-plans/{learningPlanId}/lessons:next", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var lesson = await response.Content.ReadFromJsonAsync<LessonResponse>();
+        lesson.Should().NotBeNull();
+
+        return lesson!;
+    }
+
+    private async Task<LearningPlanResponse> CreateLearningPlanAsync()
+    {
+        var student = await CreateStudentAsync();
+        await SubmitInitialAssessmentAsync(student.Id, 7, 10);
+
+        var response = await Client.PostAsync($"/students/{student.Id}/learning-plans", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var plan = await response.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        plan.Should().NotBeNull();
+
+        return plan!;
+    }
+
+    private async Task<StudentResponse> CreateStudentAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/students", new CreateStudentRequest
+        {
+            FullName = "Feedback Student",
+            Age = 10,
+            TutorEmail = $"parent.feedback.{Guid.NewGuid():N}@example.com",
+            TargetLevel = "B1"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var student = await response.Content.ReadFromJsonAsync<StudentResponse>();
+        student.Should().NotBeNull();
+
+        return student!;
+    }
+
+    private async Task SubmitInitialAssessmentAsync(Guid studentId, int correctAnswers, int totalQuestions)
+    {
+        var response = await Client.PostAsJsonAsync(
+            $"/students/{studentId}/assessments/initial",
+            new SubmitInitialAssessmentRequest
+            {
+                CorrectAnswers = correctAnswers,
+                TotalQuestions = totalQuestions
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}

--- a/tests/EnglishSeedEngine.UnitTests/Lessons/ParentFeedbackTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/Lessons/ParentFeedbackTests.cs
@@ -1,0 +1,27 @@
+using EnglishSeedEngine.Domain.Lessons;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.UnitTests.Lessons;
+
+public sealed class ParentFeedbackTests
+{
+    [Theory]
+    [InlineData("too_easy", 1)]
+    [InlineData("adequate", 0)]
+    [InlineData("too_hard", -1)]
+    public void Create_WithValidRating_MapsDifficultyDelta(string rating, int expectedDelta)
+    {
+        var feedback = ParentFeedback.Create(Guid.NewGuid(), rating, DateTime.UtcNow);
+
+        feedback.Rating.Should().Be(rating);
+        feedback.DifficultyDelta.Should().Be(expectedDelta);
+    }
+
+    [Fact]
+    public void Create_WithInvalidRating_ThrowsArgumentException()
+    {
+        var action = () => ParentFeedback.Create(Guid.NewGuid(), "invalid", DateTime.UtcNow);
+
+        action.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Summary
- add parent feedback endpoint for lessons with accepted values: 	oo_easy, dequate, 	oo_hard
- persist feedback and map it to difficulty deltas (+1 / 0 / -1)
- adapt next lesson generation difficulty using latest feedback from the previous lesson
- add integration and unit tests for happy path and negative scenarios

## Testing
- dotnet test --no-restore

Closes #10