### PR TITLE
feat: add student progress overview endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 - Lesson materials generation (versioned) and retrieval endpoints.
 - Practice session lifecycle with scoring and weak points endpoints.
 - Parent feedback endpoint to tune next lesson difficulty.
+- Student progress overview endpoint with aggregated metrics.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 

--- a/src/EnglishSeedEngine.Api/Contracts/Students/StudentProgressOverviewResponse.cs
+++ b/src/EnglishSeedEngine.Api/Contracts/Students/StudentProgressOverviewResponse.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Api.Contracts.Students;
+
+public sealed record StudentProgressOverviewResponse(
+    Guid StudentId,
+    string CurrentLevel,
+    int CompletedSessions,
+    int? LastFiveAverageScore,
+    string RecommendedFocus,
+    bool HasSessions);

--- a/src/EnglishSeedEngine.Api/Controllers/StudentsController.cs
+++ b/src/EnglishSeedEngine.Api/Controllers/StudentsController.cs
@@ -9,10 +9,14 @@ namespace EnglishSeedEngine.Api.Controllers;
 public sealed class StudentsController : ControllerBase
 {
     private readonly IStudentService _studentService;
+    private readonly IStudentProgressService _studentProgressService;
 
-    public StudentsController(IStudentService studentService)
+    public StudentsController(
+        IStudentService studentService,
+        IStudentProgressService studentProgressService)
     {
         _studentService = studentService;
+        _studentProgressService = studentProgressService;
     }
 
     [HttpPost]
@@ -92,6 +96,18 @@ public sealed class StudentsController : ControllerBase
         return Ok(ToLevelResponse(student));
     }
 
+    [HttpGet("{id:guid}/progress/overview")]
+    public async Task<IActionResult> GetStudentProgressOverview([FromRoute] Guid id, CancellationToken cancellationToken)
+    {
+        var overview = await _studentProgressService.GetOverviewAsync(id, cancellationToken);
+        if (overview is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ToProgressOverviewResponse(overview));
+    }
+
     private static StudentResponse ToResponse(Domain.Students.Student student)
     {
         return new StudentResponse(
@@ -112,6 +128,17 @@ public sealed class StudentsController : ControllerBase
             student.InitialAssessmentScorePercentage!.Value,
             student.InitialAssessmentLevel!,
             student.InitialAssessmentCompletedAtUtc!.Value);
+    }
+
+    private static StudentProgressOverviewResponse ToProgressOverviewResponse(StudentProgressOverview overview)
+    {
+        return new StudentProgressOverviewResponse(
+            overview.StudentId,
+            overview.CurrentLevel,
+            overview.CompletedSessions,
+            overview.LastFiveAverageScore,
+            overview.RecommendedFocus,
+            overview.HasSessions);
     }
 
     private static class RouteNames

--- a/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
+++ b/src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.http
@@ -35,6 +35,11 @@ Accept: application/json
 
 ###
 
+GET {{EnglishSeedEngine.Api_HostAddress}}/students/{{studentId}}/progress/overview
+Accept: application/json
+
+###
+
 POST {{EnglishSeedEngine.Api_HostAddress}}/students/{{studentId}}/learning-plans
 
 ###

--- a/src/EnglishSeedEngine.Api/Program.cs
+++ b/src/EnglishSeedEngine.Api/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddScoped<IParentFeedbackService, ParentFeedbackService>();
 builder.Services.AddScoped<ILessonService, LessonService>();
 builder.Services.AddScoped<IPracticeSessionService, PracticeSessionService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
+builder.Services.AddScoped<IStudentProgressService, StudentProgressService>();
 builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();

--- a/src/EnglishSeedEngine.Application/Students/CompletedPracticeSessionSnapshot.cs
+++ b/src/EnglishSeedEngine.Application/Students/CompletedPracticeSessionSnapshot.cs
@@ -1,0 +1,6 @@
+namespace EnglishSeedEngine.Application.Students;
+
+public sealed record CompletedPracticeSessionSnapshot(
+    int ScorePercentage,
+    DateTime FinishedAtUtc,
+    string WeakPointsJson);

--- a/src/EnglishSeedEngine.Application/Students/IStudentProgressRepository.cs
+++ b/src/EnglishSeedEngine.Application/Students/IStudentProgressRepository.cs
@@ -1,0 +1,8 @@
+namespace EnglishSeedEngine.Application.Students;
+
+public interface IStudentProgressRepository
+{
+    Task<IReadOnlyCollection<CompletedPracticeSessionSnapshot>> GetCompletedSessionsByStudentIdAsync(
+        Guid studentId,
+        CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/Students/IStudentProgressService.cs
+++ b/src/EnglishSeedEngine.Application/Students/IStudentProgressService.cs
@@ -1,0 +1,6 @@
+namespace EnglishSeedEngine.Application.Students;
+
+public interface IStudentProgressService
+{
+    Task<StudentProgressOverview?> GetOverviewAsync(Guid studentId, CancellationToken cancellationToken);
+}

--- a/src/EnglishSeedEngine.Application/Students/StudentProgressOverview.cs
+++ b/src/EnglishSeedEngine.Application/Students/StudentProgressOverview.cs
@@ -1,0 +1,9 @@
+namespace EnglishSeedEngine.Application.Students;
+
+public sealed record StudentProgressOverview(
+    Guid StudentId,
+    string CurrentLevel,
+    int CompletedSessions,
+    int? LastFiveAverageScore,
+    string RecommendedFocus,
+    bool HasSessions);

--- a/src/EnglishSeedEngine.Application/Students/StudentProgressService.cs
+++ b/src/EnglishSeedEngine.Application/Students/StudentProgressService.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using EnglishSeedEngine.Domain.Students;
+using Microsoft.Extensions.Logging;
+
+namespace EnglishSeedEngine.Application.Students;
+
+public sealed class StudentProgressService : IStudentProgressService
+{
+    private readonly IStudentRepository _studentRepository;
+    private readonly IStudentProgressRepository _studentProgressRepository;
+    private readonly ILogger<StudentProgressService> _logger;
+
+    public StudentProgressService(
+        IStudentRepository studentRepository,
+        IStudentProgressRepository studentProgressRepository,
+        ILogger<StudentProgressService> logger)
+    {
+        _studentRepository = studentRepository;
+        _studentProgressRepository = studentProgressRepository;
+        _logger = logger;
+    }
+
+    public async Task<StudentProgressOverview?> GetOverviewAsync(Guid studentId, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Student progress overview requested for student {StudentId}", studentId);
+
+        var student = await _studentRepository.GetByIdAsync(studentId, cancellationToken);
+        if (student is null)
+        {
+            _logger.LogWarning("Student progress overview skipped because student {StudentId} was not found", studentId);
+            return null;
+        }
+
+        var completedSessions = await _studentProgressRepository.GetCompletedSessionsByStudentIdAsync(studentId, cancellationToken);
+        var lastFiveSessions = completedSessions
+            .OrderByDescending(x => x.FinishedAtUtc)
+            .Take(5)
+            .ToArray();
+
+        var hasSessions = completedSessions.Count > 0;
+        var lastFiveAverageScore = StudentProgressInsights.CalculateLastFiveAverage(lastFiveSessions.Select(x => x.ScorePercentage).ToArray());
+
+        var weakPoints = lastFiveSessions
+            .SelectMany(x => DeserializeWeakPoints(x.WeakPointsJson))
+            .ToArray();
+
+        var recommendedFocus = hasSessions
+            ? StudentProgressInsights.CalculateRecommendedFocus(weakPoints)
+            : "Start with the first practice session.";
+
+        var currentLevel = student.InitialAssessmentLevel ?? student.TargetLevel;
+
+        var overview = new StudentProgressOverview(
+            studentId,
+            currentLevel,
+            completedSessions.Count,
+            lastFiveAverageScore,
+            recommendedFocus,
+            hasSessions);
+
+        _logger.LogInformation(
+            "Student progress overview generated for student {StudentId} with {CompletedSessions} completed sessions",
+            studentId,
+            overview.CompletedSessions);
+
+        return overview;
+    }
+
+    private static IReadOnlyCollection<string> DeserializeWeakPoints(string weakPointsJson)
+    {
+        if (string.IsNullOrWhiteSpace(weakPointsJson))
+        {
+            return [];
+        }
+
+        return JsonSerializer.Deserialize<string[]>(weakPointsJson) ?? [];
+    }
+}

--- a/src/EnglishSeedEngine.Domain/Students/StudentProgressInsights.cs
+++ b/src/EnglishSeedEngine.Domain/Students/StudentProgressInsights.cs
@@ -1,0 +1,44 @@
+namespace EnglishSeedEngine.Domain.Students;
+
+public static class StudentProgressInsights
+{
+    public static int? CalculateLastFiveAverage(IReadOnlyCollection<int> scores)
+    {
+        ArgumentNullException.ThrowIfNull(scores);
+
+        if (scores.Count == 0)
+        {
+            return null;
+        }
+
+        return (int)Math.Round(scores.Average(), MidpointRounding.AwayFromZero);
+    }
+
+    public static string CalculateRecommendedFocus(IReadOnlyCollection<string> weakPoints)
+    {
+        ArgumentNullException.ThrowIfNull(weakPoints);
+
+        if (weakPoints.Count == 0)
+        {
+            return "Maintain current practice plan.";
+        }
+
+        var mostFrequentWeakPoint = weakPoints
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim().ToLowerInvariant())
+            .GroupBy(x => x)
+            .OrderByDescending(x => x.Count())
+            .ThenBy(x => x.Key, StringComparer.Ordinal)
+            .Select(x => x.Key)
+            .FirstOrDefault();
+
+        return mostFrequentWeakPoint switch
+        {
+            "cloze" => "Grammar and sentence completion",
+            "translation" => "Translation accuracy",
+            "dictation" => "Listening and dictation",
+            null => "Maintain current practice plan.",
+            _ => $"{mostFrequentWeakPoint} practice"
+        };
+    }
+}

--- a/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
+++ b/src/EnglishSeedEngine.Infrastructure/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
 
         services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
         services.AddScoped<IStudentRepository, StudentRepository>();
+        services.AddScoped<IStudentProgressRepository, StudentProgressRepository>();
         services.AddScoped<ILearningPlanRepository, LearningPlanRepository>();
         services.AddScoped<ILessonRepository, LessonRepository>();
         services.AddScoped<IParentFeedbackRepository, ParentFeedbackRepository>();

--- a/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/StudentProgressRepository.cs
+++ b/src/EnglishSeedEngine.Infrastructure/Persistence/Repositories/StudentProgressRepository.cs
@@ -1,0 +1,35 @@
+using EnglishSeedEngine.Application.Students;
+using EnglishSeedEngine.Domain.PracticeSessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnglishSeedEngine.Infrastructure.Persistence.Repositories;
+
+public sealed class StudentProgressRepository : IStudentProgressRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public StudentProgressRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyCollection<CompletedPracticeSessionSnapshot>> GetCompletedSessionsByStudentIdAsync(
+        Guid studentId,
+        CancellationToken cancellationToken)
+    {
+        return await (
+            from practiceSession in _dbContext.PracticeSessions.AsNoTracking()
+            join lesson in _dbContext.Lessons.AsNoTracking() on practiceSession.LessonId equals lesson.Id
+            join learningPlan in _dbContext.LearningPlans.AsNoTracking() on lesson.LearningPlanId equals learningPlan.Id
+            where learningPlan.StudentId == studentId
+                  && practiceSession.Status == PracticeSession.Statuses.Finished
+                  && practiceSession.ScorePercentage.HasValue
+                  && practiceSession.FinishedAtUtc.HasValue
+            orderby practiceSession.FinishedAtUtc descending
+            select new CompletedPracticeSessionSnapshot(
+                practiceSession.ScorePercentage!.Value,
+                practiceSession.FinishedAtUtc!.Value,
+                practiceSession.WeakPointsJson))
+            .ToArrayAsync(cancellationToken);
+    }
+}

--- a/tests/EnglishSeedEngine.IntegrationTests/Students/StudentProgressOverviewEndpointsTests.cs
+++ b/tests/EnglishSeedEngine.IntegrationTests/Students/StudentProgressOverviewEndpointsTests.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using System.Net.Http.Json;
+using EnglishSeedEngine.Api.Contracts.LearningPlans;
+using EnglishSeedEngine.Api.Contracts.Lessons;
+using EnglishSeedEngine.Api.Contracts.PracticeSessions;
+using EnglishSeedEngine.Api.Contracts.Students;
+using EnglishSeedEngine.IntegrationTests.Infrastructure;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.IntegrationTests.Students;
+
+[Collection(ApiTestCollection.Name)]
+public sealed class StudentProgressOverviewEndpointsTests : ApiTestBase
+{
+    public StudentProgressOverviewEndpointsTests(ApiIntegrationTestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetOverview_ReturnsAggregatedMetrics()
+    {
+        var setup = await CreateLessonWithMaterialsSetupAsync();
+
+        await CompletePracticeSessionAsync(setup.Lesson.Id, setup.Material, ["translation"]);
+        await CompletePracticeSessionAsync(setup.Lesson.Id, setup.Material, ["translation"]);
+        await CompletePracticeSessionAsync(setup.Lesson.Id, setup.Material, ["dictation"]);
+        await CompletePracticeSessionAsync(setup.Lesson.Id, setup.Material, ["translation", "dictation"]);
+        await CompletePracticeSessionAsync(setup.Lesson.Id, setup.Material, []);
+
+        var response = await Client.GetAsync($"/students/{setup.Student.Id}/progress/overview");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var overview = await response.Content.ReadFromJsonAsync<StudentProgressOverviewResponse>();
+        overview.Should().NotBeNull();
+        overview!.StudentId.Should().Be(setup.Student.Id);
+        overview.CurrentLevel.Should().Be("A2");
+        overview.CompletedSessions.Should().Be(5);
+        overview.LastFiveAverageScore.Should().Be(67);
+        overview.RecommendedFocus.Should().Be("Translation accuracy");
+        overview.HasSessions.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetOverview_StudentNotFound_Returns404()
+    {
+        var response = await Client.GetAsync($"/students/{Guid.NewGuid()}/progress/overview");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetOverview_NoSessions_ReturnsEmptyState()
+    {
+        var student = await CreateStudentAsync("No Session Student");
+
+        var response = await Client.GetAsync($"/students/{student.Id}/progress/overview");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var overview = await response.Content.ReadFromJsonAsync<StudentProgressOverviewResponse>();
+        overview.Should().NotBeNull();
+        overview!.StudentId.Should().Be(student.Id);
+        overview.CompletedSessions.Should().Be(0);
+        overview.LastFiveAverageScore.Should().BeNull();
+        overview.RecommendedFocus.Should().Be("Start with the first practice session.");
+        overview.HasSessions.Should().BeFalse();
+    }
+
+    private async Task CompletePracticeSessionAsync(
+        Guid lessonId,
+        LessonMaterialResponse material,
+        IReadOnlyCollection<string> wrongTypes)
+    {
+        var startResponse = await Client.PostAsJsonAsync(
+            "/practice-sessions",
+            new CreatePracticeSessionRequest { LessonId = lessonId });
+        startResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var session = await startResponse.Content.ReadFromJsonAsync<PracticeSessionResponse>();
+        session.Should().NotBeNull();
+
+        var answers = material.Exercises
+            .Select((exercise, index) => new SubmitPracticeSessionAnswerRequest
+            {
+                ExerciseIndex = index + 1,
+                Answer = wrongTypes.Contains(exercise.Type, StringComparer.OrdinalIgnoreCase)
+                    ? "wrong answer"
+                    : exercise.ExpectedAnswer
+            })
+            .ToArray();
+
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"/practice-sessions/{session!.Id}/answers",
+            new SubmitPracticeSessionAnswersRequest { Answers = answers });
+        submitResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var finishResponse = await Client.PostAsync($"/practice-sessions/{session.Id}:finish", content: null);
+        finishResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task<(StudentResponse Student, LessonResponse Lesson, LessonMaterialResponse Material)> CreateLessonWithMaterialsSetupAsync()
+    {
+        var student = await CreateStudentAsync("Progress Student");
+        await SubmitInitialAssessmentAsync(student.Id, 7, 10);
+
+        var plan = await CreateLearningPlanAsync(student.Id);
+        var lesson = await CreateNextLessonAsync(plan.Id);
+        var material = await GenerateLessonMaterialsAsync(lesson.Id);
+
+        return (student, lesson, material);
+    }
+
+    private async Task<StudentResponse> CreateStudentAsync(string fullName)
+    {
+        var response = await Client.PostAsJsonAsync("/students", new CreateStudentRequest
+        {
+            FullName = fullName,
+            Age = 12,
+            TutorEmail = $"parent.progress.{Guid.NewGuid():N}@example.com",
+            TargetLevel = "B1"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var student = await response.Content.ReadFromJsonAsync<StudentResponse>();
+        student.Should().NotBeNull();
+
+        return student!;
+    }
+
+    private async Task SubmitInitialAssessmentAsync(Guid studentId, int correctAnswers, int totalQuestions)
+    {
+        var response = await Client.PostAsJsonAsync(
+            $"/students/{studentId}/assessments/initial",
+            new SubmitInitialAssessmentRequest
+            {
+                CorrectAnswers = correctAnswers,
+                TotalQuestions = totalQuestions
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    private async Task<LearningPlanResponse> CreateLearningPlanAsync(Guid studentId)
+    {
+        var response = await Client.PostAsync($"/students/{studentId}/learning-plans", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var plan = await response.Content.ReadFromJsonAsync<LearningPlanResponse>();
+        plan.Should().NotBeNull();
+
+        return plan!;
+    }
+
+    private async Task<LessonResponse> CreateNextLessonAsync(Guid learningPlanId)
+    {
+        var response = await Client.PostAsync($"/learning-plans/{learningPlanId}/lessons:next", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var lesson = await response.Content.ReadFromJsonAsync<LessonResponse>();
+        lesson.Should().NotBeNull();
+
+        return lesson!;
+    }
+
+    private async Task<LessonMaterialResponse> GenerateLessonMaterialsAsync(Guid lessonId)
+    {
+        var response = await Client.PostAsync($"/lessons/{lessonId}/materials:generate", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var material = await response.Content.ReadFromJsonAsync<LessonMaterialResponse>();
+        material.Should().NotBeNull();
+
+        return material!;
+    }
+}

--- a/tests/EnglishSeedEngine.UnitTests/Students/StudentProgressInsightsTests.cs
+++ b/tests/EnglishSeedEngine.UnitTests/Students/StudentProgressInsightsTests.cs
@@ -1,0 +1,31 @@
+using EnglishSeedEngine.Domain.Students;
+using FluentAssertions;
+
+namespace EnglishSeedEngine.UnitTests.Students;
+
+public sealed class StudentProgressInsightsTests
+{
+    [Fact]
+    public void CalculateLastFiveAverage_WithScores_ReturnsRoundedAverage()
+    {
+        var result = StudentProgressInsights.CalculateLastFiveAverage([67, 67, 67, 33, 100]);
+
+        result.Should().Be(67);
+    }
+
+    [Fact]
+    public void CalculateLastFiveAverage_WithoutScores_ReturnsNull()
+    {
+        var result = StudentProgressInsights.CalculateLastFiveAverage([]);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void CalculateRecommendedFocus_WithRepeatedWeakPoint_ReturnsMappedFocus()
+    {
+        var result = StudentProgressInsights.CalculateRecommendedFocus(["translation", "dictation", "translation"]);
+
+        result.Should().Be("Translation accuracy");
+    }
+}


### PR DESCRIPTION
## Summary
- add GET /students/{id}/progress/overview to return aggregated progress metrics
- include current level, completed sessions, last-5 average score, recommended focus, and empty-state handling
- add progress aggregation service + repository over finished practice sessions
- add integration and unit tests for aggregated metrics, missing student, and no-session scenarios

## Testing
- dotnet test --no-restore

Closes #11