### PR TITLE
infra: dockerize local api and postgres environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+**/bin
+**/obj
+**/TestResults
+**/*.user
+**/*.suo
+.vs
+.vscode
+node_modules
+artifacts

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Backend-first project for adaptive English learning focused on testing quality.
 - Practice session lifecycle with scoring and weak points endpoints.
 - Parent feedback endpoint to tune next lesson difficulty.
 - Student progress overview endpoint with aggregated metrics.
+- Dockerized local environment with API + PostgreSQL via `docker compose`.
 - Health endpoint.
 - Integration tests with real PostgreSQL in Docker (`Testcontainers` + `Respawn`).
 
@@ -30,6 +31,28 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the branch naming convention and PR f
 
 ```bash
 dotnet run --project src/EnglishSeedEngine.Api
+```
+
+## Run With Docker Compose
+
+```bash
+docker compose up --build
+```
+
+- API base URL: `http://localhost:8080`
+- Health endpoint: `http://localhost:8080/health`
+- PostgreSQL host from your machine: `localhost:5432`
+
+Stop and remove containers:
+
+```bash
+docker compose down
+```
+
+Stop and also remove PostgreSQL persisted volume:
+
+```bash
+docker compose down -v
 ```
 
 ## Run Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: englishseed-postgres
+    environment:
+      POSTGRES_DB: englishseed_dev
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - englishseed_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d englishseed_dev"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  api:
+    build:
+      context: .
+      dockerfile: src/EnglishSeedEngine.Api/Dockerfile
+    container_name: englishseed-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__Postgres: Host=postgres;Port=5432;Database=englishseed_dev;Username=postgres;Password=postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+
+volumes:
+  englishseed_postgres_data:

--- a/src/EnglishSeedEngine.Api/Dockerfile
+++ b/src/EnglishSeedEngine.Api/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY EnglishSeedEngine.sln ./
+COPY src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.csproj src/EnglishSeedEngine.Api/
+COPY src/EnglishSeedEngine.Application/EnglishSeedEngine.Application.csproj src/EnglishSeedEngine.Application/
+COPY src/EnglishSeedEngine.Domain/EnglishSeedEngine.Domain.csproj src/EnglishSeedEngine.Domain/
+COPY src/EnglishSeedEngine.Infrastructure/EnglishSeedEngine.Infrastructure.csproj src/EnglishSeedEngine.Infrastructure/
+
+RUN dotnet restore src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.csproj
+
+COPY . .
+RUN dotnet publish src/EnglishSeedEngine.Api/EnglishSeedEngine.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "EnglishSeedEngine.Api.dll"]


### PR DESCRIPTION
## Summary
- add production-style multi-stage Dockerfile for the API (.NET 8)
- add docker-compose.yml with API + PostgreSQL, env vars, healthchecks, and persisted DB volume
- add .dockerignore to speed up builds and reduce context size
- document docker startup and teardown workflow in README

## Verification
- docker compose config
- docker compose up --build -d
- health check: GET http://localhost:8080/health returns 200
- docker compose down
- dotnet test --no-restore

Closes #12